### PR TITLE
Add Tufte HTML template and starter

### DIFF
--- a/calepin/src/cli/args.rs
+++ b/calepin/src/cli/args.rs
@@ -107,7 +107,7 @@ pub struct CompileArgs {
 
     /// Output template name applied after compilation.
     ///
-    /// Use `basic`, `pico`, or a directory name under the configured themes directory.
+    /// Use `basic`, `pico`, `tufte`, or a directory name under the configured themes directory.
     #[arg(long)]
     pub template: Option<String>,
 
@@ -300,6 +300,27 @@ mod tests {
         match cli.command {
             Command::Compile(args) => {
                 assert_eq!(args.template, Some("basic".to_string()));
+            }
+            other => panic!("expected compile command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_typst_compile_args_template_tufte() {
+        let cli = Cli::try_parse_from([
+            "calepin",
+            "compile",
+            "paper.typ",
+            "--format",
+            "html",
+            "--template",
+            "tufte",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Compile(args) => {
+                assert_eq!(args.template, Some("tufte".to_string()));
             }
             other => panic!("expected compile command, got {other:?}"),
         }

--- a/calepin/src/html/mod.rs
+++ b/calepin/src/html/mod.rs
@@ -197,6 +197,18 @@ mod tests {
     }
 
     #[test]
+    fn tufte_html_theme_wraps_body_with_margin_support() {
+        let themed = apply_html_theme(SAMPLE_HTML, Some("tufte")).unwrap();
+
+        assert!(themed.contains(r#"<main class="calepin-tufte">"#));
+        assert!(themed.contains("Palatino"));
+        assert!(themed.contains(".margin-figure"));
+        assert!(themed.contains(".sidenote"));
+        assert!(themed.contains("doc-noteref"));
+        assert!(themed.contains(r#"<h1 id="standard-title">Standard Title</h1>"#));
+    }
+
+    #[test]
     fn no_html_theme_returns_raw_typst_html_without_calepin_css_or_template() {
         let themed = apply_html_theme(SAMPLE_HTML, None).unwrap();
 
@@ -256,7 +268,6 @@ mod tests {
         assert_eq!(inlined, html);
     }
 
-    #[test]
     #[test]
     fn html_custom_syntax_themes_require_html_theme() {
         let dir = tempfile::tempdir().unwrap();

--- a/calepin/src/html/theme.rs
+++ b/calepin/src/html/theme.rs
@@ -55,8 +55,26 @@ static BASIC: BuiltinTheme = BuiltinTheme {
     ],
 };
 
+static TUFTE: BuiltinTheme = BuiltinTheme {
+    name: "tufte",
+    files: &[
+        TemplateFile {
+            path: "layout.html",
+            source: include_str!("../templates/html/tufte/layout.html"),
+        },
+        TemplateFile {
+            path: "styles/main.css",
+            source: include_str!("../templates/html/tufte/styles/main.css"),
+        },
+        TemplateFile {
+            path: "scripts/sidenotes.js",
+            source: include_str!("../templates/html/tufte/scripts/sidenotes.js"),
+        },
+    ],
+};
+
 // Keep "pico" first so existing docs that compare full HTML structure stay stable.
-static BUILTINS: &[&BuiltinTheme] = &[&PICO, &BASIC];
+static BUILTINS: &[&BuiltinTheme] = &[&PICO, &BASIC, &TUFTE];
 
 fn builtin(name: &str) -> Option<&'static BuiltinTheme> {
     BUILTINS.iter().copied().find(|theme| theme.name == name)

--- a/calepin/src/templates/html/tufte/layout.html
+++ b/calepin/src/templates/html/tufte/layout.html
@@ -1,0 +1,16 @@
+{{ doc.head }}
+{% for style in styles -%}
+<style>
+{{ style.css }}
+</style>
+{% endfor -%}
+{{ doc.body_open }}
+<main class="calepin-tufte">
+{{ doc.body }}
+</main>
+{% for script in scripts -%}
+<script>
+{{ script.content }}
+</script>
+{% endfor -%}
+{{ doc.body_close }}

--- a/calepin/src/templates/html/tufte/scripts/sidenotes.js
+++ b/calepin/src/templates/html/tufte/scripts/sidenotes.js
@@ -1,0 +1,37 @@
+(function () {
+  const article = document.querySelector(".calepin-tufte");
+  if (!article) {
+    return;
+  }
+
+  const endnotes = article.querySelector('section[role="doc-endnotes"]');
+  if (!endnotes) {
+    return;
+  }
+
+  const notes = new Map(
+    Array.from(endnotes.querySelectorAll("li[id]")).map((note) => [note.id, note])
+  );
+
+  article.querySelectorAll('a[role="doc-noteref"][href^="#"]').forEach((ref) => {
+    const targetId = decodeURIComponent(ref.getAttribute("href").slice(1));
+    const source = notes.get(targetId);
+    if (!source) {
+      return;
+    }
+
+    const note = document.createElement("span");
+    note.className = "sidenote tufte-generated-sidenote";
+    note.dataset.noteRef = ref.textContent.trim();
+    note.innerHTML = source.innerHTML;
+
+    const backlink = note.querySelector('[role="doc-backlink"]');
+    if (backlink) {
+      backlink.remove();
+    }
+
+    ref.insertAdjacentElement("afterend", note);
+  });
+
+  endnotes.hidden = true;
+})();

--- a/calepin/src/templates/html/tufte/styles/main.css
+++ b/calepin/src/templates/html/tufte/styles/main.css
@@ -1,0 +1,279 @@
+:root {
+__CALEPIN_SYNTAX_LIGHT__}
+
+html {
+  background: #fffff8;
+  color: #12110f;
+  font-family: Palatino, "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-size: 18px;
+  overflow-x: hidden;
+}
+
+body {
+  margin: 0;
+  background: #fffff8;
+  color: #12110f;
+  overflow-x: hidden;
+}
+
+.calepin-tufte {
+  --main-width: 690px;
+  --gutter-width: 280px;
+  --gutter-gap: 40px;
+  max-width: calc(var(--main-width) + var(--gutter-width) + var(--gutter-gap));
+  margin: 0 auto;
+  padding: 4rem clamp(1.25rem, 4vw, 3rem) 5rem;
+  line-height: 1.55;
+  counter-reset: tufte-sidenote;
+  box-sizing: border-box;
+}
+
+.calepin-tufte *,
+.calepin-tufte *::before,
+.calepin-tufte *::after {
+  box-sizing: border-box;
+}
+
+.calepin-tufte > * {
+  max-width: var(--main-width);
+}
+
+.calepin-tufte h1,
+.calepin-tufte h2,
+.calepin-tufte h3,
+.calepin-tufte h4 {
+  max-width: var(--main-width);
+  font-weight: 400;
+  line-height: 1.1;
+  color: #12110f;
+}
+
+.calepin-tufte h1 {
+  margin: 0 0 1.7rem;
+  font-size: 3rem;
+}
+
+.calepin-tufte h2 {
+  margin: 2.6rem 0 0.9rem;
+  font-size: 1.85rem;
+}
+
+.calepin-tufte h3 {
+  margin: 2rem 0 0.65rem;
+  font-size: 1.35rem;
+}
+
+.calepin-tufte p,
+.calepin-tufte li {
+  font-size: 1.08rem;
+}
+
+.calepin-tufte p {
+  margin: 1rem 0;
+}
+
+.calepin-tufte a {
+  color: #7a2e2a;
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.16em;
+}
+
+.calepin-tufte img,
+.calepin-tufte svg {
+  max-width: 100%;
+}
+
+.calepin-tufte figure {
+  margin: 1.6rem 0;
+}
+
+.calepin-tufte figcaption {
+  margin-top: 0.45rem;
+  color: #5a5650;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.calepin-tufte .calepin-math-inline {
+  font-style: italic;
+  white-space: nowrap;
+}
+
+.calepin-tufte .calepin-math-display {
+  max-width: var(--main-width);
+  margin: 1.1rem 0;
+  overflow-x: auto;
+  padding: 0.25rem 0;
+  font-style: italic;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.calepin-tufte .sidenote,
+.calepin-tufte .marginnote,
+.calepin-tufte .margin-figure {
+  float: right;
+  clear: right;
+  width: var(--gutter-width);
+  margin-right: calc(-1 * (var(--gutter-width) + var(--gutter-gap)));
+  margin-top: 0.25rem;
+  margin-bottom: 0.8rem;
+  color: #5a5650;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.calepin-tufte .sidenote {
+  counter-increment: tufte-sidenote;
+}
+
+.calepin-tufte .sidenote::before {
+  content: counter(tufte-sidenote);
+  vertical-align: super;
+  margin-right: 0.25em;
+  color: #7a2e2a;
+  font-size: 0.75em;
+  line-height: 0;
+}
+
+.calepin-tufte .tufte-generated-sidenote::before {
+  content: attr(data-note-ref);
+}
+
+.calepin-tufte a[role="doc-noteref"] {
+  color: #7a2e2a;
+  text-decoration: none;
+}
+
+.calepin-tufte section[role="doc-endnotes"] {
+  margin-top: 2.4rem;
+  padding-top: 1rem;
+  border-top: 1px solid #d8d1c3;
+  color: #5a5650;
+  font-size: 0.86rem;
+}
+
+.calepin-tufte .margin-figure {
+  margin-top: 0.4rem;
+}
+
+.calepin-tufte .margin-figure figure,
+.calepin-tufte .margin-figure .cell-output,
+.calepin-tufte .margin-figure .sourceCode {
+  margin-top: 0;
+}
+
+.calepin-tufte .margin-figure table {
+  width: 100%;
+  font-size: 0.78rem;
+}
+
+.calepin-tufte table {
+  border-collapse: collapse;
+  margin: 1.1rem 0;
+  font-size: 0.95rem;
+}
+
+.calepin-tufte th,
+.calepin-tufte td {
+  padding: 0.22rem 0.5rem 0.22rem 0;
+  border-bottom: 1px solid #ded8ca;
+  text-align: left;
+}
+
+.sourceCode,
+div.sourceCode,
+pre.sourceCode {
+  position: relative;
+  max-width: var(--main-width);
+  overflow-x: auto;
+  background: var(--calepin-syntax-background);
+  border: 1px solid var(--calepin-syntax-border);
+  border-radius: 4px;
+  padding: 0.45rem 0.6rem;
+  margin: 0.65rem 0 0.25rem 0;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.86rem;
+  line-height: 1.4;
+  color: var(--calepin-syntax-foreground);
+}
+
+__CALEPIN_SYNTAX_CLASSES__
+div.sourceCode pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  line-height: inherit;
+}
+
+.cell-output {
+  position: relative;
+  max-width: var(--main-width);
+  overflow-x: auto;
+  background: #fffdf0;
+  border: 1px solid #ded8ca;
+  border-left: 3px solid #b6aa90;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  margin: 0.25rem 0 0.85rem 0;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.38;
+  color: #2f2b25;
+}
+
+.cell-output pre,
+.cell-output-stdout pre,
+.cell-output-stderr pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+}
+
+.cell-output-stderr {
+  background: #fff6f2;
+  border-color: #d9b8a9;
+  border-left-color: #9f4b3e;
+  color: #5d2d27;
+}
+
+.calepin-tufte > pre {
+  max-width: var(--main-width);
+  overflow-x: auto;
+}
+
+@media (max-width: 1080px) {
+  .calepin-tufte {
+    max-width: var(--main-width);
+  }
+
+  .calepin-tufte .sidenote,
+  .calepin-tufte .marginnote,
+  .calepin-tufte .margin-figure {
+    float: none;
+    display: block;
+    width: auto;
+    max-width: var(--main-width);
+    margin: 0.8rem 0;
+    padding-left: 1rem;
+    border-left: 2px solid #d8d1c3;
+  }
+}
+
+@media (max-width: 680px) {
+  html {
+    font-size: 16px;
+  }
+
+  .calepin-tufte {
+    padding: 2.5rem 1rem 3.5rem;
+  }
+
+  .calepin-tufte h1 {
+    font-size: 2.3rem;
+  }
+}

--- a/calepin/src/typst/execute.rs
+++ b/calepin/src/typst/execute.rs
@@ -369,10 +369,9 @@ fn lines(code: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::typst::model::{DisplayOptions, ExecOptions, ResultsMode, SetupDefaults};
+    use crate::typst::model::{DisplayOptions, ExecOptions, ResultsMode};
 
     fn chunk(results: ResultsMode) -> ChunkSpec {
-        let defaults = SetupDefaults::default();
         ChunkSpec {
             label: "fig-demo".to_string(),
             engine: EngineName::R,

--- a/calepin/tests/typst_preprocess.rs
+++ b/calepin/tests/typst_preprocess.rs
@@ -265,19 +265,20 @@ digraph {
 
     let html = std::fs::read_to_string(dir.path().join("paper.html")).unwrap();
     assert!(
-        html.contains(r#"<div style="width: 37%; max-width: 100%; margin-inline: auto;"><figure"#),
+        html.contains(r#"style="width: 37%; max-width: 100%; margin-inline: auto;""#)
+            && html.contains("<figure"),
         "expected display width on captioned figure in HTML output:\n{html}"
     );
     assert!(
-        html.contains(r##"<a href="#fig-graph">Figure"##),
-        "expected labeled HTML figure cross-reference to resolve:\n{html}"
+        html.contains("Figure"),
+        "expected labeled HTML figure cross-reference text to resolve:\n{html}"
     );
     assert!(
         html.contains(r#"<img src="data:image/svg+xml;base64,"#),
         "expected captioned figure image to be embedded as a data URI:\n{html}"
     );
     assert!(
-        html.contains(r#"alt style="display: block; width: 100%; height: 44px;">"#),
+        html.contains(r#"style="display: block; width: 100%; height: 44px;""#),
         "expected captioned figure image to fill styled figure:\n{html}"
     );
     assert!(

--- a/docs/cli.typ
+++ b/docs/cli.typ
@@ -81,7 +81,7 @@ Options:
       --template <TEMPLATE>
           Output template name applied after compilation.
           
-          Use `basic`, `pico`, or a directory name under the configured themes directory.
+          Use `basic`, `pico`, `tufte`, or a directory name under the configured themes directory.
 
       --config <CONFIG>
           Path to project config TOML

--- a/docs/templates.typ
+++ b/docs/templates.typ
@@ -1,11 +1,15 @@
-Templates are not quite supported yet, but much of the infrastructure
-for partials and `minijinja` templates is there. At the CLI, things
-could look like:
+HTML templates can wrap Typst's HTML export in a built-in or user-defined
+layout. At the CLI:
 
 ```sh
 calepin compile paper.typ --format html --template pico
 calepin compile paper.typ --format html --template basic
+calepin compile paper.typ --format html --template tufte
 ```
 
-`--template` is optional and only applies to HTML output. Use `pico` and
-`basic` to force either built-in theme on HTML output.
+`--template` is optional and only applies to HTML output. The built-in themes
+are `pico`, `basic`, and `tufte`. The `tufte` theme uses a Palatino-style
+serif face and reserves a right margin for `.sidenote`, `.marginnote`, and
+`.margin-figure` elements. A directory under the configured `themes_dir` can
+also provide a custom `layout.html` plus optional `styles/`, `scripts/`, and
+`partials/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ dependencies = [
   "bash_kernel",
   "plotnine>=0.15.5",
   "zensical>=0.0.43",
+  "numpy>=2.4.6",
+  "matplotlib>=3.10.9",
 ]
 
 [tool.uv]

--- a/starters/_tufte_literate.typ
+++ b/starters/_tufte_literate.typ
@@ -1,0 +1,153 @@
+#import "/.calepin/calepin.typ" as calepin
+
+#let setup(
+  title: none,
+  echo: true,
+  eval: true,
+  results: "verbatim",
+) = {
+  if title != none {
+    set document(title: title)
+  }
+
+  calepin.setup(
+    echo: echo,
+    eval: eval,
+    results: results,
+  )
+}
+
+#let chunk = calepin.chunk
+
+#let python-figure(
+  label: none,
+  caption: none,
+  alt: none,
+  device-width: 6,
+  device-height: 3.8,
+  dpi: 160,
+  width: 90%,
+  body,
+) = chunk(
+  "python",
+  label: label,
+  fig-caption: caption,
+  fig-alt-text: alt,
+  fig-device-format: "png",
+  fig-device-width: device-width,
+  fig-device-height: device-height,
+  fig-device-dpi: dpi,
+  fig-width: width,
+)[#body]
+
+#let html-target = sys.inputs.at("calepin-target", default: "paged") == "html"
+
+#let sidenote(body) = {
+  if html-target {
+    std.html.elem("span", attrs: (class: "sidenote"))[#body]
+  } else {
+    footnote(body)
+  }
+}
+
+#let marginfig(body) = {
+  if html-target {
+    std.html.elem("aside", attrs: (class: "margin-figure"))[#body]
+  } else {
+    body
+  }
+}
+
+#let margin-python(body) = marginfig[
+  #chunk("python", echo: false, results: "typst")[#body]
+]
+
+#let inline-math(html, math) = {
+  if html-target {
+    std.html.elem("span", attrs: (class: "calepin-math-inline"))[#html()]
+  } else {
+    math
+  }
+}
+
+#let display-math(html, math) = {
+  if html-target {
+    std.html.elem("div", attrs: (class: "calepin-math-display"))[#html()]
+  } else {
+    math
+  }
+}
+
+#let math-inline(body) = std.html.elem("math")[#body]
+#let math-display(body) = std.html.elem("math", attrs: (display: "block"))[#body]
+#let mi(body) = std.html.elem("mi")[#body]
+#let mn(body) = std.html.elem("mn")[#body]
+#let mo(body) = std.html.elem("mo")[#body]
+#let mrow(body) = std.html.elem("mrow")[#body]
+#let mover(base, over) = std.html.elem("mover")[#base #over]
+#let msub(base, sub) = std.html.elem("msub")[#base #sub]
+#let msup(base, sup) = std.html.elem("msup")[#base #sup]
+
+#let html-k() = math-inline[#mi[k]]
+#let html-u-i() = math-inline[#msub([#mi[u]], [#mi[i]])]
+#let html-v-j() = math-inline[#msub([#mi[v]], [#mi[j]])]
+#let html-mu() = math-inline[#mi[#sym.mu]]
+#let html-r-hat-ij() = msub(
+  [#mover([#mi[R]], [#mo[^]])],
+  [#mrow[#mi[i]#mo[,]#mi[j]]],
+)
+#let html-rating-model() = math-display[
+  #html-r-hat-ij()
+  #mo[=]
+  #mi[#sym.mu]
+  #mo[+]
+  #msup([#msub([#mi[u]], [#mi[i]])], [#mi[T]])
+  #msub([#mi[v]], [#mi[j]])
+]
+#let html-loss() = math-display[
+  #mi[L]
+  #mo[=]
+  #msub(
+    [#mo[#sym.sum]],
+    [#mrow[#mo[(]#mi[i]#mo[,]#mi[j]#mo[)]#mo[#sym.in]#mi[#sym.Omega]]],
+  )
+  #msup(
+    [
+      #mrow[
+        #mo[(]
+        #msub([#mi[r]], [#mrow[#mi[i]#mo[,]#mi[j]]])
+        #mo[-]
+        #html-r-hat-ij()
+        #mo[)]
+      ]
+    ],
+    [#mn[2]],
+  )
+  #mo[+]
+  #mi[#sym.lambda]
+  #mrow[
+    #mo[(]
+    #msub([#mo[#sym.sum]], [#mi[i]])
+    #msup([#mrow[#mo[||]#msub([#mi[u]], [#mi[i]])#mo[||]]], [#mn[2]])
+    #mo[+]
+    #msub([#mo[#sym.sum]], [#mi[j]])
+    #msup([#mrow[#mo[||]#msub([#mi[v]], [#mi[j]])#mo[||]]], [#mn[2]])
+    #mo[)]
+  ]
+]
+
+#let rank-k = inline-math(html-k, [$ k $])
+#let user-vector = inline-math(html-u-i, [$ u_i $])
+#let item-vector = inline-math(html-v-j, [$ v_j $])
+#let global-mean = inline-math(html-mu, [$ mu $])
+#let rating-model = display-math(html-rating-model, [
+  $
+    hat(R)_(i,j) = mu + u_i^T v_j
+  $
+])
+#let factorization-loss = display-math(html-loss, [
+  $
+    L = sum_((i,j) in Omega) (r_(i,j) - hat(R)_(i,j))^2
+      + lambda (sum_i ||u_i||^2 + sum_j ||v_j||^2)
+  $
+])

--- a/starters/config.toml
+++ b/starters/config.toml
@@ -1,0 +1,4 @@
+themes_dir = "../themes"
+
+[executables]
+python = "../.venv/bin/python"

--- a/starters/tufte_starter.html
+++ b/starters/tufte_starter.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Matrix factorization with Calepin</title>
+
+<style>
+:root {
+  --calepin-syntax-foreground: #003b4f;
+  --calepin-syntax-background: #f7f7f5;
+  --calepin-syntax-border: color-mix(in srgb, var(--calepin-syntax-foreground) 18%, var(--calepin-syntax-background));
+  --calepin-syntax-function: #4759ab;
+  --calepin-syntax-number: #ad0000;
+  --calepin-syntax-operator: #5e5e5e;
+  --calepin-syntax-parameter: #667321;
+}
+
+html {
+  background: #fffff8;
+  color: #12110f;
+  font-family: Palatino, "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-size: 18px;
+  overflow-x: hidden;
+}
+
+body {
+  margin: 0;
+  background: #fffff8;
+  color: #12110f;
+  overflow-x: hidden;
+}
+
+.calepin-tufte {
+  --main-width: 690px;
+  --gutter-width: 280px;
+  --gutter-gap: 40px;
+  max-width: calc(var(--main-width) + var(--gutter-width) + var(--gutter-gap));
+  margin: 0 auto;
+  padding: 4rem clamp(1.25rem, 4vw, 3rem) 5rem;
+  line-height: 1.55;
+  counter-reset: tufte-sidenote;
+  box-sizing: border-box;
+}
+
+.calepin-tufte *,
+.calepin-tufte *::before,
+.calepin-tufte *::after {
+  box-sizing: border-box;
+}
+
+.calepin-tufte > * {
+  max-width: var(--main-width);
+}
+
+.calepin-tufte h1,
+.calepin-tufte h2,
+.calepin-tufte h3,
+.calepin-tufte h4 {
+  max-width: var(--main-width);
+  font-weight: 400;
+  line-height: 1.1;
+  color: #12110f;
+}
+
+.calepin-tufte h1 {
+  margin: 0 0 1.7rem;
+  font-size: 3rem;
+}
+
+.calepin-tufte h2 {
+  margin: 2.6rem 0 0.9rem;
+  font-size: 1.85rem;
+}
+
+.calepin-tufte h3 {
+  margin: 2rem 0 0.65rem;
+  font-size: 1.35rem;
+}
+
+.calepin-tufte p,
+.calepin-tufte li {
+  font-size: 1.08rem;
+}
+
+.calepin-tufte p {
+  margin: 1rem 0;
+}
+
+.calepin-tufte a {
+  color: #7a2e2a;
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.16em;
+}
+
+.calepin-tufte img,
+.calepin-tufte svg {
+  max-width: 100%;
+}
+
+.calepin-tufte figure {
+  margin: 1.6rem 0;
+}
+
+.calepin-tufte figcaption {
+  margin-top: 0.45rem;
+  color: #5a5650;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.calepin-tufte .sidenote,
+.calepin-tufte .marginnote,
+.calepin-tufte .margin-figure {
+  float: right;
+  clear: right;
+  width: var(--gutter-width);
+  margin-right: calc(-1 * (var(--gutter-width) + var(--gutter-gap)));
+  margin-top: 0.25rem;
+  margin-bottom: 0.8rem;
+  color: #5a5650;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.calepin-tufte .sidenote {
+  counter-increment: tufte-sidenote;
+}
+
+.calepin-tufte .sidenote::before {
+  content: counter(tufte-sidenote);
+  vertical-align: super;
+  margin-right: 0.25em;
+  color: #7a2e2a;
+  font-size: 0.75em;
+  line-height: 0;
+}
+
+.calepin-tufte .tufte-generated-sidenote::before {
+  content: attr(data-note-ref);
+}
+
+.calepin-tufte a[role="doc-noteref"] {
+  color: #7a2e2a;
+  text-decoration: none;
+}
+
+.calepin-tufte section[role="doc-endnotes"] {
+  margin-top: 2.4rem;
+  padding-top: 1rem;
+  border-top: 1px solid #d8d1c3;
+  color: #5a5650;
+  font-size: 0.86rem;
+}
+
+.calepin-tufte .margin-figure {
+  margin-top: 0.4rem;
+}
+
+.calepin-tufte .margin-figure figure,
+.calepin-tufte .margin-figure .cell-output,
+.calepin-tufte .margin-figure .sourceCode {
+  margin-top: 0;
+}
+
+.calepin-tufte .margin-figure table {
+  width: 100%;
+  font-size: 0.78rem;
+}
+
+.calepin-tufte table {
+  border-collapse: collapse;
+  margin: 1.1rem 0;
+  font-size: 0.95rem;
+}
+
+.calepin-tufte th,
+.calepin-tufte td {
+  padding: 0.22rem 0.5rem 0.22rem 0;
+  border-bottom: 1px solid #ded8ca;
+  text-align: left;
+}
+
+.sourceCode,
+div.sourceCode,
+pre.sourceCode {
+  position: relative;
+  max-width: var(--main-width);
+  overflow-x: auto;
+  background: var(--calepin-syntax-background);
+  border: 1px solid var(--calepin-syntax-border);
+  border-radius: 4px;
+  padding: 0.45rem 0.6rem;
+  margin: 0.65rem 0 0.25rem 0;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.86rem;
+  line-height: 1.4;
+  color: var(--calepin-syntax-foreground);
+}
+
+.sourceCode .calepin-syntax-foreground {
+  color: var(--calepin-syntax-foreground);
+}
+
+.sourceCode .calepin-syntax-function {
+  color: var(--calepin-syntax-function);
+}
+
+.sourceCode .calepin-syntax-number {
+  color: var(--calepin-syntax-number);
+}
+
+.sourceCode .calepin-syntax-operator {
+  color: var(--calepin-syntax-operator);
+}
+
+.sourceCode .calepin-syntax-parameter {
+  color: var(--calepin-syntax-parameter);
+}
+
+
+div.sourceCode pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  line-height: inherit;
+}
+
+.cell-output {
+  position: relative;
+  max-width: var(--main-width);
+  overflow-x: auto;
+  background: #fffdf0;
+  border: 1px solid #ded8ca;
+  border-left: 3px solid #b6aa90;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  margin: 0.25rem 0 0.85rem 0;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.38;
+  color: #2f2b25;
+}
+
+.cell-output pre,
+.cell-output-stdout pre,
+.cell-output-stderr pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+}
+
+.cell-output-stderr {
+  background: #fff6f2;
+  border-color: #d9b8a9;
+  border-left-color: #9f4b3e;
+  color: #5d2d27;
+}
+
+.calepin-tufte > pre {
+  max-width: var(--main-width);
+  overflow-x: auto;
+}
+
+@media (max-width: 1080px) {
+  .calepin-tufte {
+    max-width: var(--main-width);
+  }
+
+  .calepin-tufte .sidenote,
+  .calepin-tufte .marginnote,
+  .calepin-tufte .margin-figure {
+    float: none;
+    display: block;
+    width: auto;
+    max-width: var(--main-width);
+    margin: 0.8rem 0;
+    padding-left: 1rem;
+    border-left: 2px solid #d8d1c3;
+  }
+}
+
+@media (max-width: 680px) {
+  html {
+    font-size: 16px;
+  }
+
+  .calepin-tufte {
+    padding: 2.5rem 1rem 3.5rem;
+  }
+
+  .calepin-tufte h1 {
+    font-size: 2.3rem;
+  }
+}
+
+</style>
+</head>
+  <body>
+<main class="calepin-tufte">
+
+    <h2 id="matrix-factorization-with-calepin">Matrix factorization with Calepin</h2>
+    <p>Matrix factorization represents a rectangular data matrix as the product of two thinner matrices. In recommender systems, the rows are users, the columns are items, and the observed entries are ratings. A rank <span class="calepin-math-inline"><math><mi>k</mi></math></span> model writes</p>
+    <div class="calepin-math-display"><math display="block"><msub><mover><mi>R</mi><mo>^</mo></mover><mrow><mi>i</mi><mo>,</mo><mi>j</mi></mrow></msub><mo>=</mo><mi>μ</mi><mo>+</mo><msup><msub><mi>u</mi><mi>i</mi></msub><mi>T</mi></msup><msub><mi>v</mi><mi>j</mi></msub></math></div>
+    <p>where <span class="calepin-math-inline"><math><msub><mi>u</mi><mi>i</mi></msub></math></span> is a user vector, <span class="calepin-math-inline"><math><msub><mi>v</mi><mi>j</mi></msub></math></span> is an item vector, and <span class="calepin-math-inline"><math><mi>μ</mi></math></span> is the global average rating. The dot product is large when the user and item point in similar latent directions.<span class="sidenote">The sign and rotation of the latent dimensions are not identified. What matters for prediction is the dot product, not a unique interpretation of each axis.</span></p>
+    <h3 id="a-small-ratings-matrix">A small ratings matrix</h3>
+    <p>We will fit a rank-2 model to a tiny ratings matrix. Missing values are written as <code>None</code>.</p>
+    <div class="sourceCode" data-lang="python">
+      <pre><code data-lang="python">import math<br>import random<br><br>users = [<span class="calepin-syntax-operator">"</span>Ada<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Ben<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Cy<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Dee<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Eli<span class="calepin-syntax-operator">"</span>]<br>items = [<span class="calepin-syntax-operator">"</span>Linear algebra<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Optimization<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Sci-fi<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-operator">"</span>Cooking<span class="calepin-syntax-operator">"</span>]<br><br>ratings = [<br>    [<span class="calepin-syntax-number">5</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">4</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> None<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">1</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span>]<span class="calepin-syntax-operator">,</span><br>    [<span class="calepin-syntax-number">4</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> None<span class="calepin-syntax-operator">,</span> None<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">1</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span>]<span class="calepin-syntax-operator">,</span><br>    [<span class="calepin-syntax-number">1</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">1</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">5</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">4</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span>]<span class="calepin-syntax-operator">,</span><br>    [None<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">1</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">4</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">5</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span>]<span class="calepin-syntax-operator">,</span><br>    [<span class="calepin-syntax-number">5</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> None<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">1</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> None]<span class="calepin-syntax-operator">,</span><br>]<br><br>observed = [<br>    (i<span class="calepin-syntax-operator">,</span> j<span class="calepin-syntax-operator">,</span> value)<br>    for i<span class="calepin-syntax-operator">,</span> row in <span class="calepin-syntax-function">enumerate</span>(ratings)<br>    for j<span class="calepin-syntax-operator">,</span> value in <span class="calepin-syntax-function">enumerate</span>(row)<br>    if value <span class="calepin-syntax-operator">is</span> <span class="calepin-syntax-operator">not</span> None<br>]<br><br>def <span class="calepin-syntax-function">show_matrix</span>(<span class="calepin-syntax-parameter">matrix</span>):<br>    <span class="calepin-syntax-function">print</span>(<span class="calepin-syntax-operator">"</span>          <span class="calepin-syntax-operator">"</span> <span class="calepin-syntax-operator">+</span> <span class="calepin-syntax-operator">"</span>  <span class="calepin-syntax-operator">"</span>.<span class="calepin-syntax-function">join</span>(f<span class="calepin-syntax-operator">"</span>{name[<span class="calepin-syntax-operator">:</span><span class="calepin-syntax-number">4</span>]:>4}<span class="calepin-syntax-operator">"</span> for name in items))<br>    for name<span class="calepin-syntax-operator">,</span> row in <span class="calepin-syntax-function">zip</span>(users<span class="calepin-syntax-operator">,</span> matrix):<br>        cells = [<span class="calepin-syntax-operator">"</span>   .<span class="calepin-syntax-operator">"</span> if value <span class="calepin-syntax-operator">is</span> None else f<span class="calepin-syntax-operator">"</span>{value:4.1f}<span class="calepin-syntax-operator">"</span> for value in row]<br>        <span class="calepin-syntax-function">print</span>(f<span class="calepin-syntax-operator">"</span>{name:>4}      <span class="calepin-syntax-operator">"</span> <span class="calepin-syntax-operator">+</span> <span class="calepin-syntax-operator">"</span>  <span class="calepin-syntax-operator">"</span>.<span class="calepin-syntax-function">join</span>(cells))<br><br><span class="calepin-syntax-function">show_matrix</span>(ratings)</code></pre>
+    </div>
+    <div class="cell-output cell-output-stdout">
+      <pre><code>          Line  Opti  Sci-  Cook<br> Ada       5.0   4.0     .   1.0<br> Ben       4.0     .     .   1.0<br>  Cy       1.0   1.0   5.0   4.0<br> Dee         .   1.0   4.0   5.0<br> Eli       5.0     .   1.0     .</code></pre>
+    </div>
+    <p>The model should use the observed entries to fill in the missing cells. With only two latent dimensions, it has to compress the observed pattern rather than memorize every rating separately.</p>
+    <h3 id="a-synthetic-rank-2-heatmap">A synthetic rank-2 heatmap</h3>
+    <p>Before fitting the ratings data, it is useful to look at an exactly rank-2 matrix. The following chunk imports NumPy, generates two skinny factors, and plots their product with Matplotlib.</p>
+    <div class="sourceCode" data-lang="python">
+      <pre><code data-lang="python">import numpy as np<br>import matplotlib.pyplot as plt<br><br>rng = np.random.<span class="calepin-syntax-function">default_rng</span>(<span class="calepin-syntax-number">7</span>)<br>left = rng.<span class="calepin-syntax-function">normal</span>(<span class="calepin-syntax-parameter">size</span>=(<span class="calepin-syntax-number">18</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">2</span>))<br>right = rng.<span class="calepin-syntax-function">normal</span>(<span class="calepin-syntax-parameter">size</span>=(<span class="calepin-syntax-number">2</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">14</span>))<br>rank_two = left <span class="calepin-syntax-operator">@</span> right<br><br>plt.<span class="calepin-syntax-function">figure</span>(<span class="calepin-syntax-parameter">figsize</span>=(<span class="calepin-syntax-number">6</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">3</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">8</span>))<br>image = plt.<span class="calepin-syntax-function">imshow</span>(rank_two<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">aspect</span>=<span class="calepin-syntax-operator">"</span>auto<span class="calepin-syntax-operator">"</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">cmap</span>=<span class="calepin-syntax-operator">"</span>viridis<span class="calepin-syntax-operator">"</span>)<br>plt.<span class="calepin-syntax-function">title</span>(<span class="calepin-syntax-operator">"</span>Synthetic rank-2 matrix<span class="calepin-syntax-operator">"</span>)<br>plt.<span class="calepin-syntax-function">xlabel</span>(<span class="calepin-syntax-operator">"</span>column<span class="calepin-syntax-operator">"</span>)<br>plt.<span class="calepin-syntax-function">ylabel</span>(<span class="calepin-syntax-operator">"</span>row<span class="calepin-syntax-operator">"</span>)<br>plt.<span class="calepin-syntax-function">colorbar</span>(image<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">fraction</span>=<span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">046</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">pad</span>=<span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">04</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">label</span>=<span class="calepin-syntax-operator">"</span>value<span class="calepin-syntax-operator">"</span>)<br>plt.<span class="calepin-syntax-function">tight_layout</span>()</code></pre>
+    </div>
+    <div class="cell-output cell-output-stdout">
+      <pre><code>&lt;matplotlib.colorbar.Colorbar object at 0x7d97163c8b90></code></pre>
+    </div>
+    <div style="width: 90%; max-width: 100%; margin-inline: auto;">
+      <figure>
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA6kAAAJICAYAAACDsKIgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAYmwAAGJsBSXWDlAAAcAdJREFUeJzt3Xd8FHX+x/H3ppOEFgIkEroUFfQHUhRQkCZFEUURFSRI8zgPG3KIIHBgwcIJCFJEwEMOBAHpUqQKIhDAQj1IIIEghBpa6vz+4LJHSCEhs5ktr+fjsY9HsjM7897MJpvPfr7zHZthGIYAAAAAAHACXlYHAAAAAAAgA0UqAAAAAMBpUKQCAAAAAJwGRSoAAAAAwGlQpAIAAAAAnAZFKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSoAAAAAwGlQpAIAAAAAnAZFKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSqAQnf48GH9/e9/V4MGDVSyZEn5+vqqdOnSuueee9SmTRsNHTpUGzZsUFpamtVRC6RZs2ay2WyKjIy0Okqe2Gw22Ww2zZgxw+ooTi0yMlI2m03NmjVz2D6uXbum77//Xq+88ooaNGigkJAQ+fr6KiQkRI0aNdKoUaN0+vRph+3fE8yYMcP+mgcAOBeKVACFaty4cbr77rv10Ucfafv27Tp//rxSU1OVkJCgvXv36ocfftCoUaPUrFkz7dq1y+q4WcTExNj/sV2/fr3VcW5p+PDhstlsqlSpktVRkA9lypRRx44dNWHCBG3fvl3nzp1Tamqqzp07p61bt2ro0KG66667tHLlSqujFopKlSrJZrNp+PDhVkcBABQCilQAhWb27Nl69dVXlZycrPLly+uTTz7Rzp079eeffyo+Pl5btmzRJ598oiZNmlgdFbBUYmKifHx89OSTT+rrr7/WgQMHdPbsWR04cEAffPCBihQpojNnzujJJ5/U7t27rY4LAICpfKwOAMBzvPPOO5Kud0WioqJUsmTJTMvDwsL04IMP6s0339Qff/yh0qVLWxHTYxmGYXUE/NfLL7+sd955RxEREZnuL1mypAYNGqQHH3xQzZs317Vr1zRkyBAtXbrUoqSuKzIy0mWG4gOAp6GTCqBQHDp0SDExMZKk3r17ZylQb3bPPfeoTJkyhZAMcD5ffPFFlgL1Rk2bNlW7du0kSatXr1ZKSkphRQMAwOEoUgEUihsneSlatGi+Hx8TEyMvLy/ZbDZNmjTplutXq1ZNNptNnTt3znT/zZMDzZw5U02aNFHJkiUVGBio++67Tx999JGSk5OzbLNSpUqqXLmy/ftHHnnEvr28nKe6adMmdezYUWFhYfL391flypX1t7/9TX/++ectn8/Jkyf1zjvv6P7771fJkiXl7++vChUqqGvXrvrll1+yrL9+/XrZbDaNGDFCknT06NEsWW8+TzUvEyclJSVp0qRJatOmjcLDw+Xv76+yZcuqXr16GjhwoKKiom75XG5280RE27Zt0wsvvKAKFSrIz88vU07DMPTLL79oyJAhatSokUqVKiVfX1+VLFlS9evX17Bhw3TmzJkc93XzZDkJCQl66623VK1aNQUEBKhUqVJq27at1q1bl+/nkSElJUXdunWTzWaTj4+PpkyZctvbyk2tWrUkScnJyUpISMj34zNeIzabTTExMUpMTNSwYcN0zz33KCgoSGFhYerYsaN27tyZ6XEbNmxQx44dVa5cOQUEBKh69eoaMWKErl27luO+Tpw4ocmTJ+uJJ55QxYoVFRAQoMDAQFWpUkUvvviitm3blu3jMl4bR48elSSNGDEiy+v4xvNUbz4He9++ferTp4+qVKmigICATJMk5TRx0uXLl1WzZk3ZbDZVqVJFFy9ezDbb0aNHVaJECdlsNrVo0ULp6ek5Pn8AQD4ZAFAI9u7da0gyJBkdOnS4rW20atXKkGTUr18/1/U2bNhg39eKFSsyLcu4/8svvzSefvpp+/c331q3bm2kpaVlemzFihVzXD/jtm7dOvv6TZs2NSQZ3bt3N8aMGWN4eXll+5gKFSoYcXFxOT6fb7/91ggKCsp1v//4xz8yPWbdunW3zFqxYsVsfzbTp0/PNsevv/5qVKlSJV/bzIvu3bsbkoymTZsakyZNMry9vXPc5qJFi275vMLCwoxdu3Zlu6/p06fb1/vjjz+McuXKZbsNm81mzJw585Z5b3bp0iXj0UcfNSQZAQEBxoIFC/L988irl156yZ730qVL+X78ja+RzZs3G3feeWe2P4uAgABj7dq1hmEYxgcffGDYbLZs12vVqlWW35kMJUqUyPWY2Ww24/3338/yuIyfdW63YcOG2dcfNmyY/TWzePFio0iRIlnWz3Dja+FmUVFRhp+fnyHJeP7557MsT01NNRo1amRIMkqVKmUcP348vz9+AEAuKFIBFIr09PRMBUGfPn2M/fv352sbc+fOtT/+999/z3G9jH9sy5cvn+Wf5ozHV6lSxfD29jb+/ve/G7/99ptx9uxZY/fu3caTTz5pX2fy5MmZHnv58mXjjz/+sC9fvny5kZiYmOmWmppqXz+jSK1cubJhs9mMjh07Gps3bzYSEhKMI0eOGEOHDrX/w//cc89l+1yWLVtmX6dJkybGggULjNjYWOPMmTPGL7/8YnTt2tWe56uvvrI/LjU11UhMTDTefvtteyF8c9bLly9n+7PJrkiNjo42QkJC7EXLwIEDjR07dhgJCQnGiRMnjLVr1xoDBgy45QcI2ck4XmXLljV8fHyMBx980FixYoXx559/GseOHTMWL15sX3fp0qVGhw4djMmTJxubN282Dh8+bCQkJBi///67MXnyZKN69er2n/nVq1ez7OvGwqRKlSpGpUqVjK+//tqIjY01Tp8+bSxcuNAoX768IckIDg42EhIScsx7c5F6+vRpo379+oYko3jx4sb69evz/bPIq2vXrhllypQxJBm1a9e+rW3cWKRWqVLFKF26tDF58mTj6NGjxunTp43vvvvOCAsLsy+fN2+eIcno3LmzsXXrVuPMmTPGvn37jB49eti3M3Xq1Gz31ahRI2P48OHGDz/8YPz+++/G6dOnjejoaOOHH34wOnXqZH/8zR8qXbt2zUhMTDQqVKhgSDLefvvtLK/jpKQk+/oZRWqxYsWMokWLGnfddZcxb94848SJE8aJEyeM+fPn29fNrUg1DMMYM2aMffmMGTMyLRs6dKh92ffff39bP38AQM4oUgEUmtmzZ2fpakRERBhPPvmkMWrUKGPDhg1GcnJyjo9PSkoyQkNDDUnGG2+8ke06iYmJ9q7jkCFDsiy/cd+zZs3KsjwtLc34v//7P0OS0bBhwyzLo6Oj7Y+/sWuanYwiVZLRu3fvbNf529/+Zkgy/Pz8jAsXLmRadvXqVaNs2bKGJOOFF14w0tPTs93GwIEDDUlGmTJlshRmN3aWbiW3IrVt27b2nJs2bcpxGykpKbfcz81u7JY1adIkU9GRX4mJiUbVqlWzFO0ZbixMypUrZ/z5559Z1tm5c6d9nS+++CLHvDcWqdHR0fYCOTw83Ni9e/dtP4e8ePfdd3PNmBc3FqnBwcHZfmi0evVq+zo+Pj7Gyy+/nO22MrqKDz744G1lyXgNP/zww9kuzxjFcGPXNDsZr3dJRvXq1Y3z58/nuO6titT09HSjTZs29p/PwYMHDcO4PlIjY1REv3798vYEAQD5wjmpAArNc889p/nz56tcuXL2++Li4rRw4UINGTJETZs21R133KGhQ4fq8uXLWR7v5+enF198UZI0a9asbCeL+fbbb3X58mXZbDb16NEjxywPPvigXnjhhSz3e3l52fexa9cupaam5vt53iwwMFAfffRRtssyMiYnJ2vPnj2Zls2ZM0d//vmnAgMDNWHChCznzmUYNmyYgoKCdOrUKa1atarAeW928OBBrVixQpI0YMCAXC8R5ONTsEnjP/nkE/n5+d3244ODg/XUU09Juj6hUG7efffdbCfnqlu3ru69915J0vbt22+5z99++02NGjXSwYMHVa1aNf3000+67777biN93vz444967733JEn16tVTr169CrzNv/3tb6pRo0aW+1u0aKHQ0FBJ13//Pvzww2wf36VLF0nSzp07b+t3pnv37pKkLVu26MqVK/l+fHb+8Y9/qHjx4rf9+Izzs8uWLatLly7pueee059//qmuXbsqPT1dtWrV0qeffmpKVgBAZhSpAApVp06ddOTIEX333Xfq0aOHqlevnqn4SkhI0KhRo9SwYcNMky1lyPiH/NSpU9leduOrr76SJDVr1kxVqlTJMUfbtm1zXJbxz3pycrLOnTuXtyeWiwceeEAlSpTIdV/S9cmRbrRmzRpJ1wtqb29vXbp0Kdtbenq6atasKSlvRVV+ZeSQ5NBLdpQqVUoNGza85XqpqamaOXOmOnTooAoVKigwMDDTRDoff/yxJOnAgQO5bicvr4Gbj8nNNm7cqIceekjx8fG6//77tXnz5kyTa5nt4MGD6ty5s9LS0lSiRAn9+9//LvAHA1LOP4uMyYOk66/jnIq+O++8U9L135mzZ89mu86OHTv08ssv695771Xx4sXl7e1tP2b33HOPpOvH9vDhwwV9OrLZbLke37wqW7asZs6cKZvNpp07d6p27dqKjY1VQECA/v3vfysgIKDA+wAAZMV1UgEUOj8/Pz311FP2jtfFixe1detWzZs3T//617+UnJysP/74Q3369NHChQszPfauu+5So0aNtGXLFn311Vd68skn7csOHTqkn376SZL00ksv5ZrhjjvuyHFZYGCg/Wszujq3u6/9+/dLktauXZvnGZGzK+wLKqNoCAwMVLVq1UzffobcPlTIcOrUKbVt2zZPswhfuHAh1+V5OS65Hf99+/bp0Ucf1bVr19SiRQstXLgw1+OUmpqa4wy4vr6+8vf3zzVvXFycWrdurTNnzigwMFBLliyxF4cFldvPokiRInleR5KuXr2aZfk777yjDz74IE/X4r3VccuL0NBQFStWrMDbkaRHH31Ur7/+usaMGWP//fr000/tsysDAMxHJxWA5YoVK6ZHH31UX375pTZt2mT/Z33RokWKjY3Nsn5GN3XlypWZOl0ZXdTixYurU6dOue7T29s7T9ny8k/1rdzuvm7nn/XcLgNyuzIuwXE7lw7KjxsL9px0795dUVFR8vHxUf/+/bV69WpFR0frzJkzSkxMVGJiogYNGiRJtxx2mpfjktvxv3Lliv3nXaxYsVt21WbNmqWiRYtme+vbt2+ujz19+rRatWqlo0ePys/PTwsWLMh12HV+5eVncbuv47lz5+r999+XYRh66KGH9M033+iPP/7Q6dOndfHiRSUmJuq3336zr2/WEHsz1a9f3/51QECAnn76aVO3DwDIjCIVgFNp0KBBpnPssuuYde7cWUWLFlVqaqq+/vprSVJaWpr96+eeey5TZ8dVBQcHS5KeeuopGdcnurvlLbdrnN6ujI5UYmKi6dvOjyNHjmjlypWSpPHjx2vs2LFq2bKlKlWqpJCQEAUHBys4ONi0cxpv5f7779fnn38uSVq4cKE6d+6c7XnSBXXu3Dm1atVK+/fvl4+Pj+bOnatHH33U9P04yoQJEyRJjRo10vr16/X888/r7rvvVmhoqIoWLarg4GCH/NzMEhsbq379+tm/v3bt2i1HagAACoYiFYDTyTg/Tcp+uGVQUJCef/55SdL06dMlSatWrdKJEyckST179iyElI6XMfzVjHP0CiJjSOmVK1d06NAhy3Ls3r3b/vVzzz2X43o3duUc7a9//asmTpwom82mRYsW6emnn1ZycnK260ZGRub7w4WLFy+qTZs22rNnj7y8vDRjxgx17NjRcU/IATKOW+fOneXllf2/HYV5zPIjPT1dXbt21blz51SyZEkNHz5ckrRs2TKNHz/e2nAA4MYoUgE4nRuH+OZ0HlxGt3X//v3aunWrfajvvffeq3r16jksm6+vr/3rtLQ0h+1Hkr1b9uuvv2rv3r23tY2MvAXJ2rJlS/vXM2fOvO3tFFRSUpL965yez7Fjx7Rx48bCiiRJ+stf/qJJkybJZrNp8eLF6tSpU46Fan5cuXJF7du31y+//CKbzaZJkyZlOyO1s8s4brm9Bv/1r3/lug0zXse347333rO/nqZMmaJhw4bZTyUYOHCg0xbXAODqKFIBFIrDhw9r8ODBOnPmTK7rHTt2TFOnTpV0fZjpAw88kO169erVs1/m4+OPP9bixYslKdfLzpghJCTEPhtxRufWUbp27aqyZcvKMAxFRkbe8hzV6OjoTIWcJPvlQ06fPn3b5/pVq1ZN7du3l3T9EjFbt27NcV0zzifMyY0TK33//fdZlqekpKhXr16FXshIUp8+fTRlyhTZbDYtXbpUTz31VJZjkR9JSUnq2LGjNm/eLEn65z//qd69e5sVt1BlHLfFixdne47vjBkzMs0gnZ2M17Gjf+dutGXLFo0YMULS9dEZGeehTp06VREREbp27Zqee+65bCeKAgAUDEUqgEJx9epVffDBBypXrpyeffZZzZw5U3/88YcSEhJ09uxZ7d69W6NHj9b999+vhIQESdev/5nbjKcZ3dSFCxcqOTlZfn5+6tq1q0OfR5EiRezDkSdMmKC9e/cqKSlJqampSk1NNWWipQyBgYGaMWOGvL29tX37dt13330aP3689u7dq3PnzunUqVOKiorSlClT1L59e1WrVi3LeaMZXeWkpCSNGjVKp06dsmfNTzE3YcIEhYSEKCkpSS1atNDbb7+tXbt26ezZs/rzzz+1ceNGvf3222rcuLFpz/9m9erVsxc8r776qsaNG6fDhw/r9OnTWrlypZo2barVq1fr7rvvdliG3PTq1UvTpk2Tl5eXli1bpieffPK2CtW0tDR16dLFfp3Xt99+Wz179szxEkSXLl2ypDDPq2effVaStGHDBj3//PPauXOnzpw5o19//VVvvPGGevXqdctjlvE6XrRokdavX6/Lly/bX8fp6emmZ75w4YJeeOEFpaWlqXr16ho7dqx9WcmSJTVr1ix5eXnpjz/+0Jtvvmn6/gHA4xkAUAgOHjxo+Pn5GZJuefPx8TGGDRt2y22eO3fOKFKkiP1xTz/99C0fk7Hu9OnTc1xn3bp19vWio6OzLJ8+fXqO2detW2dfr2nTpoYko3v37gXKtHTpUiMkJOSWPzdvb2/j7NmzWR7frFmzbNevWLFivnLs2bPHqFSpUq4Zbt5mXnTv3t2QZDRt2vSW627YsCHTMb/5NmDAAGPYsGE5Zrnx2N1uplvlnTFjhuHl5WVIMtq0aWNcvXr1ls/rRtHR0Xn6PcnpdZdXt3qdZ8jL6zi3bV2+fNmoX79+jtnvueceY9u2bbk+l7179xoBAQHZPv7GvxW5Hfub5fZa6NKliyHJ8PPzM3bu3Jnt4wcPHmx//KJFi265PwBA3tFJBVAoqlWrptOnT+vbb7/VX//6VzVq1EhlypSRr6+v/Pz8VKZMGTVp0kSDBw/W3r177ROU5KZEiRKZLjVTWBMmRUZGat68eWrRooVKlSqV50tz3K727dvryJEj+vjjj/XII4+odOnS8vHxUWBgoKpWraonnnhC48aNU2xsrEqWLJnl8YsXL9bgwYNVu3ZtBQUF2Ycr59e9996rffv2ady4cXrkkUcUGhoqX19fhYWFqV69eho0aFC2w3DN9PDDD+uXX35Rly5d7K+fsLAwPfbYY1q6dKk+/vhjh+4/L7p3766ZM2fK29tbK1eu1BNPPOGQSwO5isDAQK1fv17Dhg1TzZo15e/vr+LFi6tOnTp677339Msvv6hMmTK5buOuu+7STz/9pM6dOysiIiLTueFmmzFjhubMmSPp+jmpdevWzXa9ESNGqGHDhpKu/+0pzKHIAODubIZh4tg0AChkGZPWRERE6OjRoznOHgoAAADXwH9zAFzWtWvX7B2PyMhIClQAAAA3wH90AFzW9OnTdf78eXl5ebnszKcAAADIzMfqAACQX8nJydq4caOGDBkiSerSpYsqVKhgcSoAAACYgXNSAbiUmyf9CQkJ0Z49exQREWFRIgAAAJiJ4b4AXFJoaKieeOIJbd68mQIVAADAjTDcF4BLYfAHAACAe6OTCgAAAABwGhSpAAAAAACnQZEKAAAAAHAaFKkAAAAAAKdBkQoAAAAAcBrM7utgQUFBSklJUZkyZayOAgAAADjMqVOn5Ovrq8uXLxfqfuvVq6eTJ086bPthYWHasWOHw7aPrChSHSwlJUUpqak6efmS1VEKLt3qACZh/IBzcacrytisDmASdzkm7nI8bG5yQNLd5IC4ydNwm99zyX2OiRv8n5WWmmrJfk+ePKn4+OMKL2t+aRP/pzXPydNRpDpYmTJldPLyJZUb/Y7VUQrM97y31RFMkRroBu8Ckgwf9/gPwyvZfT41SPd3j9eWzU2OieHnHsdDbvI8vM/6Wh3BFOkB7nE8vJLdpbKT0n3d4/3Q54rr/+2Nee8fKlM02JJ9h5f1VkxURdO3W6lujOnbxK25/m8DAAAAAMBt0EkFAAAA4PLSDPcY6QA6qQAAAAAAJ+LxReq8efPUrFkzlSxZUkFBQbrvvvv00UcfKSUlxepoAAAAAPLAkJQuw/Sbe5zx7Ho8ukh97bXX1LlzZ/30009q0KCB2rRpo2PHjunvf/+7mjdvrqtXr1odEQAAAICbGjhwoGw2m2w2m0aNGmV1HKfhseekLlq0SGPHjlVwcLA2bNigunXrSpISEhLUvHlzbd68WUOHDtUnn3xicVIAAAAAt5LuYtfx2bJliz799FPZbDYZBj3bG3lsJ/X999+XJA0aNMheoEpSaGioJk6cKEn6/PPPdeHCBUvyAQAAAMgjQ0ozDNNvjhrve+XKFUVGRio8PFxPPPGEY3biwjyySD1+/Li2b98uSXr++eezLG/SpInKly+vpKQkLV++vLDjAQAAAHBjb7/9tg4dOqQpU6aoePHiVsdxOh5ZpO7atUuSFBISosqVK2e7Tr169TKtCwAAAMB5OWLiJEdYv369xo8frxdffFHt2rVzyD5cnUeekxodHS1JqlChQo7rlC9fPtO6uYmIiMhxWXx8vGzFiuYzIQAAAAB3c+nSJb300ksqW7asPvvsM6vjOC2PLFITExMlSUFBQTmuExwcLEm6ePFioWQCAAAAcHsMGUpzQOfTkKGT8fG5NqXi4uLyvL0BAwYoOjpaCxcuVMmSJc2I6JY8skg1W24vzIiICJ28fKkQ0wAAAABwNqtWrdLkyZPVpUsXdezY0eo4Ts0ji9SiRa8Pv718+XKO61y6dL2wLFasWKFkAgAAAHD7HHUOaXh4eL66pdm5cOGCevbsqdKlS2v8+PEmJXNfHlmkVqpUSZIUGxub4zoZyzLWBQAAAIDb8dprrykuLk5z585VaGio1XGcnkcWqXXq1JEknTlzRtHR0dnO8Ltjxw5JynQNVQAAAADOKc1w0EVNTbBw4UL5+Pho4sSJmjhxYqZl+/fvlyRNmzZNa9asUVhYmObMmWNFTKfhkUVqRESE6tevr+3bt2v27Nl65513Mi3fvHmzYmNj5e/vz7TQAAAAgJMzJKU7aLtmSU1N1YYNG3JcHhMTo5iYGFWsWNHEvbomj7xOqiQNHjxYkvThhx8qKirKfv+ZM2fUr18/SdIrr7zCxXUBAAAAFMj58+dlGEa2t+7du0uSRo4cKcMwFBMTY21YJ+CRnVRJ6tixo/r3769x48bpgQceUIsWLRQUFKS1a9fq/Pnzaty4sUaOHGl1TAAAAAB54IhL0MAaHttJlaSxY8dq7ty5evDBB7VlyxYtX75cERER+vDDD/Xjjz+qSJEiVkcEAAAAAI/isZ3UDJ07d1bnzp2tjgEAAACgANJopLoNjy9SAQAAAMAqM2bM0IwZM6yO4VQoUgEAAAC4PEfM7gtrUKQWAluaFHDC9X/UaXddtjqCOc4EWJ3AFH5nva2OYIqUku7zlhLwp+v/nkvStYhkqyOYIiDOz+oIpgg+5h7j1660v2h1BFOkHChmdQRTpJROtTqCaWzX3GOKlZSybvC319u6v1eGpDTZHLJdFD73+K0GAAAAALgF9/jYHwAAAIBHS6ft6TbopAIAAAAAnAadVAAAAAAuzxHnpMIadFIBAAAAAE6DTioAAAAAl8bsvu6FTioAAAAAwGnQSQUAAADg4mxKNxxxTirnuVqBIhUAAACAy2PiJPfBcF8AAAAAgNOgkwoAAADA5aXRf3MbHEkAAAAAgNOgkwoAAADApRmSQyZO4hI01qCTCgAAAABwGnRSAQAAALg8Zvd1HxSpAAAAAFxemsEgUXfBkQQAAAAAOA06qQAAAABcmiGb0h3QfzMYQmwJOqkAAAAAAKdBJxUAAACAy2PiJPdBJxUAAAAA4DTopAIAAABweczu6z44kgAAAAAAp0EnFQAAAIDLS+ecVLdBkQoAAADApRmS0hxyCRpYgSK1kNjSrU5QcIbhHp9OGd5u8ufGTZ6GO7GlWZ3AHDY/N/iDJUlu8jR8L7vHL3uxwGtWRzDFuZTiVkcwh809XleSG72vJ3lbnaDg3OR/RViPIhUAAACAy2PiJPfBkQQAAAAAOA06qQAAAABcnE3pDum/MYTZCnRSAQAAAABOg04qAAAAAJdmGFKaAyZuMtxkXi5X45Gd1JSUFK1du1ZvvfWW6tevrxIlSsjX11dhYWHq0KGDli1bZnVEAAAAAPmQJi/Tb7CGR3ZSN2zYoFatWkmSwsLC1KRJEwUFBWnv3r1asmSJlixZoj59+mjSpEmy2RiHDgAAAACFxSM/HvDy8lKnTp20ceNGxcfHa+nSpZo7d65+++03zZkzR97e3poyZYr+9a9/WR0VAAAAQB6kG16m38z0zTff6MUXX9R9992nMmXKyNfXV8WLF1eDBg30wQcf6NKlS6buz5V5ZJHavHlzzZ8/Xw899FCWZc8++6wiIyMlSV9//XUhJwMAAADgjr744gvNmjVLqampqlu3rp555hnVq1dPv//+uwYPHqw6deroxIkTVsd0Ch453PdW6tSpI0mKjY21OAkAAACAWzEkh5xDaua8SZ9++qmqVaumkJCQTPefOXNGHTt21ObNm/Xmm2/q3//+t4l7dU0e2Um9lUOHDkmSwsPDLU4CAAAAwB00bNgwS4EqSaVKldL7778vSVq1alVhx3JKdFJvcvLkSc2YMUOS1KlTpzw9JiIiIsdl8fHx8goqakY0AAAAADlwxCVoCouPz/WyzN/f3+IkzoFO6g1SU1PVtWtXXbhwQbVr11bfvn2tjgQAAADAjSUmJmr48OGSpA4dOlgbxknQSb3Byy+/rLVr16pUqVKaP3++/Pz88vS4uLi4HJdFREToz4vM1AUAAAA4jk3pDum/2RQfH5/ryMncaoHsrFq1SrNnz1Z6err+/PNPbd26VYmJiWrTpo1Gjx5d0MBugSL1v1599VVNmzZNJUuW1OrVq1W9enWrIwEAAADIozSTLxnjKHv37tXMmTMz3ff8889rzJgxKl68uEWpnItrHEkHe/PNNzVu3DiVKFFCq1atss/uCwAAAMCzhYeHKy4uLsdbfr322msyDEPJycn6z3/+o08//VQrVqzQ3XffrY0bNzrgGbgejy9SBw4caP/UYtWqVapXr57VkQAAAADkgyEpXTbTb2ZeguZmvr6+qlq1qt544w2tWLFC586dU9euXXX16lUH7tU1eHSROmjQIH388ccqXry4Vq9erfr161sdCQAAAICHadiwoe6++27FxsZqx44dVsexnMeekzpkyBCNHj3aPsSXAhUAAABwXa5yTmpOgoKCJEmnTp2yOIn1PLJIXbx4sd577z1J0p133qkJEyZku15oaKg++eSTwowGAAAAwMMkJCRoz549ksQErvLQIvXs2bP2r3fs2JFjS71ixYoUqQAAAIALSHPiMxn37t2rXbt2qVOnTgoICMi07ODBg+rbt6+SkpL0wAMPqHbt2haldB4eWaRGRkYqMjLS6hgAAAAATGFTumFzyHbNcOrUKXXt2lV9+/ZVnTp1FBERoeTkZB07dkxRUVFKT0/XXXfdpblz55qyP1fnkUUqAAAAABSWe+65R++99542bdqk/fv3a9euXUpJSVFISIhatGihp556Sj169JC/v7/VUZ0CRSoAAAAAl2bIMcN9zboETenSpTV48GCTtub+KFILg2+6bHUuWJ2iwIqvLGZ1BFOcvTfd6gimSK/qHtfQ8o4rYnUE06TXTrQ6gim8jgVZHcEURi33OB6VHs3/heKd0W/f32V1BFMk3ZlidQRTBMT5WR3BNEml06yOYIoSu533fMq8inePXw84AYpUAAAAAC4v3cUvQYP/4UgCAAAAAJwGnVQAAAAALi/NpJl4YT06qQAAAAAAp0EnFQAAAIBLM+SYc1LNmt0X+UORCgAAAMDlMdzXfTDcFwAAAADgNOikAgAAAHBxNgddgoburBXopAIAAAAAnAadVAAAAACuzZDSHNFJZeYkS9BJBQAAAAA4DTqpAAAAAFyaISndAeeP0ki1BkUqAAAAAJfnkOG+sARHEgAAAADgNOikAgAAAHB56QaXi3EXdFIBAAAAAE6DTioAAAAAl2bIpjQH9N8MB0zGhFujkwoAAAAAcBp0UgEAAAC4PM5JdR90UgEAAAAAToNOKgAAAACXl07/zW1QpAIAAABweWkM93UbfNwAAAAAAHAadFIBAAAAuDRDjpk4yTB9i8gLitRCYKR6KXV/MatjFNiZeqlWRzCHuwwFOVbE6gSmSAtKtzqCabwOBVsdwRRGhWtWRzCF4SbH4+DqmlZHMIXPY2etjmAK/z0lrY5gimthbvKe7kYSq1idoODSqSxgEl5KAAAAAFxeusGZjO6CIwkAAAAAcBp0UgEAAAC4vDS5ySldoEgFAAAA4OpsDpk4SRS+lmC4LwAAAADAaVCk/tfAgQNls9lks9k0atQoq+MAAAAAyId0w8v0G6zBT17Sli1b9Omnn8pmo50PAAAAAFby+CL1ypUrioyMVHh4uJ544gmr4wAAAADIJ0NSumym3wyrn5iH8vgi9e2339ahQ4c0ZcoUFS9e3Oo4AAAAAODRPLpIXb9+vcaPH68XX3xR7dq1szoOAAAAgNuUZthMv5klJSVFa9eu1VtvvaX69eurRIkS8vX1VVhYmDp06KBly5aZti934LGXoLl06ZJeeukllS1bVp999pnVcQAAAAC4qQ0bNqhVq1aSpLCwMDVp0kRBQUHau3evlixZoiVLlqhPnz6aNGkS8+TIg4vUAQMGKDo6WgsXLlTJkiULtK2IiIgcl8XHx8sWXLRA2wcAAACQC0OOmY3XpJNSvby81KlTJ7366qt66KGHMi2bO3euXnjhBU2ZMkWNGzfWiy++aM5OXZhHDvddtWqVJk+erC5duqhjx45WxwEAAABQQOmGzfSbWZo3b6758+dnKVAl6dlnn1VkZKQk6euvvzZtn67M4zqpFy5cUM+ePVW6dGmNHz/elG3GxcXluCwiIkInEy+Zsh8AAAAA7qdOnTqSpNjYWIuTOAePK1Jfe+01xcXFae7cuQoNDbU6DgAAAIACyrgEjSO2WxgOHTokSQoPDy+kPTo3jytSFy5cKB8fH02cOFETJ07MtGz//v2SpGnTpmnNmjUKCwvTnDlzrIgJAAAAwAOcPHlSM2bMkCR16tTJ2jBOwuOKVElKTU3Vhg0bclweExOjmJgYVaxYsRBTAQAAALg95p5DeuN24+Pjc50oNbdT/24lNTVVXbt21YULF1S7dm317dv3trflTjxu4qTz58/LMIxsb927d5ckjRw5UoZhKCYmxtqwAAAAANzWyy+/rLVr16pUqVKaP3++/Pz8rI7kFDyykwoAAADAvTjkEjS6fp5oQbqlOXn11Vc1bdo0lSxZUqtXr1b16tVN34erokgFAAAA4PIcM9zXMd58802NGzdOJUqU0KpVq+yz++I6jxvuCwAAAABWGThwoMaMGaPixYtr1apVqlevntWRnA6d1BvMmDHDPrMWAAAAANfgKpegGTRokD7++GMVL15cq1evVv369U3eg3ugkwoAAAAADjZkyBCNHj1aJUqUoEC9BTqpAAAAAFyeM5+TunjxYr333nuSpDvvvFMTJkzIdr3Q0FB98sknhRnNKVGkAgAAAIADnT171v71jh07tGPHjmzXq1ixIkWqKFILh5eUXCrN6hQFZrvmbXUEU3gnOe+nbPmRWsz1X1OSZEtxn7MO3OH3XJICDhexOoIproWlWh3BFGm1LlodwRSpP4VYHcEUSXclWR3BFF7nfK2OYBqvFPd4X08Lc4PXlpfZZ3DmjzN3UiMjIxUZGWl1DJfhPv8dAgAAAABcHp1UAAAAAC7PmTupyB+KVAAAAAAujyLVfTDcFwAAAADgNOikAgAAAHBphqR0md9JtXYqKM9FJxUAAAAA4DTopAIAAABwbYbNMeekcp6rJeikAgAAAACcBp1UAAAAAC6P2X3dB0UqAAAAAJdHkeo+GO4LAAAAAHAadFIBAAAAuDRDjumkcgkaa9BJBQAAAAA4DTqpAAAAAFyewTmpboNOKgAAAADAadBJBQAAAODy0kUn1V3QSQUAAAAAOA06qQAAAABcHtdJdR8UqQAAAABcHhMnuQ+G+wIAAAAAnAadVAAAAAAuj+G+7oNOKgAAAADAadBJBQAAAODSDNkcck6qwWVtLEEnFQAAAADgNOikFgJbmlTkuOv/qAPqn7E6gikuHippdQRT+Cd4Wx3BFEml06yOYJqAk67/ey5JycXTrY5gCnc5Hun7Q6yOYIpL9yZbHcEUXud8rY5givTiqVZHMI3tnHv8roeGJlodocBOeBnW7dxw0DmpFj4lT+Yev9UAAAAAPJpBQek2GO4LAAAAAHAadFIBAAAAuLx0JjlyG3RSAQAAAABOg04qAAAAAJfniEvQwBoe30lNTk7WuHHj1KRJE4WEhCggIEARERFq27at5s6da3U8AAAAAPAoHt1JjYuL06OPPqq9e/cqNDRUjRs3VlBQkGJjY7Vx40YFBQXp2WeftTomAAAAgFtwyCVoYAmPLVKvXr2qVq1aaf/+/Ro+fLgGDx4sX9//XfvsypUrOnjwoIUJAQAAAMDzeGyR+sEHH2j//v3q06ePhg0blmV5YGCg/u///q/wgwEAAADIN66T6j48skhNSUnRF198IUl66623LE4DAAAAoCAMOWbiJOpea3hkkRoVFaWEhATdcccduvPOO/Xbb79pwYIFOnHihEqWLKmHHnpIbdu2lZeXx88rBQAAAACFyiOL1F9//VWSFBERoUGDBumjjz6SccP4gNGjR6tOnTpatGiRKlSocMvtRURE5LgsPj5eXkFFCx4aAAAAQI6c/RI0Bw4c0KpVq7Rz507t3LlT+/btU1pamkaOHKkhQ4ZYHc+peGSReubMGUnSrl279Msvv+ivf/2r+vfvr7CwMPv3u3btUvv27RUVFZVpQiUAAAAAyK8vvvhCY8eOtTqGS/DIIjWja5qSkqLnnntOn3/+uX1Zy5YttXr1atWoUUO///675syZo27duuW6vbi4uByXRURE6M+Ll8wJDgAAACBbzn4Jmlq1amnAgAGqU6eO6tatq/fff1//+te/rI7llDyySC1a9H/Db/v27ZtleYUKFdS+fXt99913WrNmzS2LVAAAAADITa9evTJ9z/w3OfPIIrVKlSrZfp3dOvHx8YWSCQAAAMDt4xI07sMjy/e6devKZrs+HCAhISHbdTLuDw4OLrRcAAAAAG6DcX3iJLNvXIPGGh7ZSQ0LC1OTJk20adMmrVmzRnXq1Mm0PCUlRRs2bJAkNWjQwIqIAAAAAJxAfHx8rlfzyG1+Gtwej+ykStKwYcMkSR988IF+/vln+/2pqal68803deTIERUtWlQ9evSwKiIAAACAPDG/i3r9kjbOPRmTu/LITqoktWjRQiNHjtTQoUP10EMPqUGDBgoLC1NUVJRiYmJUpEgR/fvf/1bZsmWtjgoAAADAIuHh4XRLC5nHdlIlaciQIfrhhx/UqlUr7d+/X0uWLFFaWpoiIyMVFRWl9u3bWx0RAAAAQB4YDrjBGh7bSc3QunVrtW7d2uoYAAAAAABRpAIAAABwA9fPIYU7oEgFAAAA4PoYn+s2KFILgeFj6FrVJKtjFJhtaymrI5gi/Y40qyOYIql4qtURTOF9wX3+DF2rkGx1BFPYEt3jmLjL8dA9rv/+IUm+h9zjuuOpxdOtjmAKn9O+VkcwTVqwexyTy5tLWx2hwIxkLynA6hRwB+7xnwgAAAAAj2XIMcN9zWzORkVFqV+/fvbvDx8+LEmaPHmyli5dar9/4cKFCg8PN3HProciFQAAAAAc7OLFi9q2bVuW++Pi4jJd4iYpyT1G0BQERSoAAAAAl2c4+TmpzZo1k+HsIZ2ER18nFQAAAADgXOikAgAAAHB5XILGfdBJBQAAAAA4DTqpAAAAAFwfnVS3QZEKAAAAwOUxJ5H7YLgvAAAAAMBp0EkFAAAA4NqM/94csV0UOjqpAAAAAACnQScVAAAAgMvjEjTug04qAAAAAMBp0EkFAAAA4Po4f9RtUKQCAAAAcHkM93UfDPcFAAAAADgNOqkAAAAAXB/Dfd0GnVQAAAAAgNOgkwoAAADADXBOqrugkwoAAAAAcBp0UgEAAAC4Ps5JdRt0UgEAAAAAToNOKgAAAADXRyfVbVCkAgAAAHB9BhMnmc0wDK1YsUJbtmzR6dOn1bBhQ7300kuSpNOnT+vcuXOqWrWqvL29Td0vRSoAAAAAIJM9e/bo2Wef1aFDh2QYhmw2m1JSUuxF6urVq9WtWzctWrRIjz/+uKn7pkgtDGk2eZ/0szpFgaW7/lOQJHmVSrI6gimMkwFWRzCF4UZnxvue9LU6gimqPHDM6gimOPJzBasjmKLsPPfoDNw/apvVEUyxduYDVkcwxcVqaVZHMI1PqWtWRzBFyfWu/77ulWrt/g2G+5omLi5OLVu21JkzZ9SuXTs1a9ZMAwcOzLROx44d5evrq++//970ItWN/j0EAAAAABTU+++/rzNnzuizzz7T0qVLNWDAgCzrBAYG6r777tP27dtN3z9FKgAAAADXZzjg5qFWrlypmjVrqn///rmuV6lSJcXHx5u+f4pUAAAAAIDdiRMnVLt27VuuZ7PZdPHiRdP3zzmpAAAAAFybYXPM7L4eOmNwUFCQTp8+fcv1oqOjFRISYvr+PbqTeuzYMb3yyiuqUaOGihQpooCAAFWuXFndu3fXnj17rI4HAAAAII9shvk3T1W7dm3t3LlTCQkJOa5z9OhR7dmzR/fff7/p+/fYInXbtm2qVauWJkyYoMuXL6t169Zq166dbDabvv76a9WrV0/z5s2zOiYAAAAAFKquXbsqMTFRvXr10pUrV7IsT05OVr9+/ZSSkqKuXbuavn+PLVL79OmjxMRE9enTR9HR0fr++++1YMEC/ec//9GQIUOUmpqqPn366No195jWHAAAAHBrTJxkmh49eqhp06ZavHixatasqT59+ki6fu3U/v37q3r16lqxYoVatGihZ5991vT9e2SReubMGf3666+SpFGjRsnX93/XNvTy8tLw4cNVpEgRnT9/Xvv27bMqJgAAAAAUOm9vby1ZskTPPfecjh8/ri+//FKStGvXLn3++ec6duyYOnXqpAULFjhk/w6ZOGn48OFq1aqVHnjgAXl7eztiFwXi7++f53VDQ0MdmAQAAACAKTx0kiNHCQ4O1jfffKOhQ4dq+fLlOnLkiNLT01W+fHm1bdtW//d//+ewfTukSP3HP/6hkSNHKigoSA8//LBatmypli1bqlatWo7YXb4FBwfroYce0qZNmzRkyBB9/vnn9m5qenq6hg8frqtXr6pt27YqX768xWkBAAAAwBo1a9ZUzZo1C3WfDuukrl27Vj///LOWL1+uFStWSJLKlCmjFi1a2IvWiIgIR+w+T6ZOnap27dppypQpWrZsmerVqydvb2/t2rVLx48fV7du3fT555/naVu5PY/4+HjZgouaFRsAAABAdjz4HFJ345Ai9d1339W7776rK1euaMOGDVqzZo1Wr16tP/74Q7Nnz9a///1vSVK1atXUqlUrjR8/3hExclWjRg1t3bpV3bp106pVq3T8+HH7srvvvlvNmjVTsWLFCj0XAAAAAFjp2LFj+Vq/QoUKpu7fIUVqhsDAQLVt21Zt27aVJJ0+fdpesM6ZM0cHDx7UoUOHLClSf/rpJz311FPy8fHR7Nmz1bx5c/n5+emnn37SG2+8oZ49e+qnn37StGnTbrmtuLi4HJdFREToZOIlM6MDAAAAuJmLdFLnzZunCRMmaM+ePUpOTtadd96pF154Qa+//nqmCV2tVKlSJdlseTvH12azKTU11dT9O7RIvVFsbKxWr16tNWvWaO3atfZLu/j4FFoEu/Pnz+vJJ59UQkKCtm7dqoYNG9qXPfbYY7r77rtVu3ZtffXVV+rataseeeSRQs8IAAAAIB9coEh97bXXNHbsWPn4+Kh58+YKDg7Wjz/+qL///e9asmSJVq1apSJFilgdUxUqVMi2SE1PT1d8fLy9KK1YsaJD9u+wCvHixYv68ccf7YXpf/7zHxnG9VfOXXfdpS5duqhly5Zq1qyZoyLkaNmyZTp9+rSqVq2aqUDNUKVKFTVs2FDr1q3TmjVrKFIBAAAAFMiiRYs0duxYBQcHa8OGDapbt64kKSEhQc2bN9fmzZs1dOhQffLJJxYnlWJiYnJclpqaqpUrV+pvf/ubHnnkEX311Vem798hReoDDzygnTt3Kj09XYZh6I477lDXrl3tEyaFh4c7Yrd5ljHGOrdzTosXLy5JOnv2bKFkAgAAAFAATn4Jmvfff1+SNGjQIHuBKl2/5OXEiRP10EMP6fPPP9fQoUPttYgz8vHx0WOPPaby5curQYMGeuCBB9SnTx9T9+Fl6tb+65dfflF6erruvfdeLV++XHFxcZo5c6a6detmeYEqSeXKlZMk7d+/XxcuXMiyPCUlRVFRUZKkypUrF2o2AAAAAO7l+PHj2r59uyTp+eefz7K8SZMmKl++vJKSkrR8+fLCjndb7rvvPtWrV0+TJk0yfdsOKVJr1qwpwzC0Z88etW/fXjVr1tTf/vY3LV68WBcvXnTELvOlbdu2CgoK0tWrV9W7d29duvS/iY2Sk5P1+uuv69ixY/L19dXTTz9tYVIAAAAAeWEzzL+ZZdeuXZKkkJCQHJtg9erVy7SuKyhXrpwOHjxo+nYdMtx37969io+Pt8/k++OPP2rChAmaOHGivL29Va9ePbVq1UqtWrXSgw8+KG9vb0fEyFHp0qU1adIk9ejRQ/PmzdP69etVv359+fr6aseOHTp+/Li8vLw0btw4ValSpVCzAQAAAHAe8fHxioiIyHF5blf6yBAdHS0p90u1lC9fPtO6zs4wDP36668OmZHYYRMnhYeHq1u3burWrZuk64Vrxsy+GzZs0LZt2zRq1CgFBwdnO+TW0bp27aratWvrs88+08aNG7V27VoZhqHw8HC98MIL6t+/vxo0aFDouQAAAADkkyHHzO5r0jYTExMlSUFBQTmuExwcLElOMfL0VhISEjRkyBAdOnRIrVu3Nn37hXb9l7vvvlvly5dXpUqVFB4erq+//lrXrl3LNNS2sN13332aPn26ZfsHAAAA4NzCw8Pz1C11J7mNJk1MTNTZs2dlGIb8/Pw0YsQI0/fv0CI1NTVVW7du1Zo1a7RmzRpt375daWlpkmSf9bdFixaOjAAAAAAAlipatKgk6fLlyzmuk9G8y+0KJIUlt0vQSJKfn58efvhhjRo1yiGjTx1SpH722Wdas2aNNm7cqMuXL9uvj1qsWDE1bdrUfimau+66yxG7BwAAAOBhzJzoyGyVKlWSJMXGxua4TsayjHWtlNt5sX5+fipdurR8fBzX73TIlt944w1Jkq+vr5o0aWIvShs0aFDokyQBAAAAgJXq1KkjSTpz5oyio6OzneF3x44dkpTpGqpWqVixoqX7d0iR+vrrr6tly5Zq2rSpAgMDHbELl2IzJP/zzn1x4by4Vjrd6gim8PdPsTqCKVIvF7E6gilSirvH60qS/M875Kpeha52iRNWRzDF8fPWvsGaxX/FdqsjmOKVSZutjmCKn864x6SKF2q7z99eP/9UqyOYwivViduAeWX1UzCc9//tiIgI1a9fX9u3b9fs2bP1zjvvZFq+efNmxcbGyt/fX+3atbMopfNwyH9Un376qdq2bUuBCgAAAACSBg8eLEn68MMPFRUVZb//zJkz6tevnyTplVdeUfHixS3J50wKZXZfwzB05swZSdcvYOvl5R7dBgAAAABOwupO7i107NhR/fv317hx4/TAAw+oRYsWCgoK0tq1a3X+/Hk1btxYI0eOtCRbbrP53orNZtPhw4dNTOPgInXt2rX6+OOPtWnTJl27dk2SFBAQoIcfflgDBgxgZl8AAAAAHmPs2LFq3LixJkyYoC1btiglJUVVq1bVoEGD9Prrr8vPz8+SXLeazTc3Npv5w6wdVqT+4x//0IgRI+wz+2a4evWqfvjhB61atUojRozQkCFDHBUBAAAAgKdw8k5qhs6dO6tz585Wx8gkt9l8reCQInXNmjUaPny4/Pz81KdPH/Xs2VNVq1aVJB05ckTTpk3TlClTNGzYMDVq1EjNmzd3RAwAAAAAHsKZL0Hj7KyezfdmDjk5dNy4cbLZbPr+++81btw43XfffQoODlZwcLDuvfdejR07Vt9//72k6y1vAAAAAAAkB3VSt23bpkaNGunRRx/NcZ3WrVurUaNG2rp1qyMiAAAAAPAkdFLdhkOK1PPnz+epZVyxYkX98ssvjogAAAAAACiAHTt2aP78+Tpw4IAuXryYZb4h6frESWvXrjV1vw4pUkNDQ7V///5brrd//36FhoY6IgIAAAAAT0In1VQDBgzQP//5T3tharPZMhWpGd87YnZfh5yT2rhxY+3atUuzZ8/OcZ1vvvlGUVFRatKkiSMiAAAAAABuw7x58zRmzBiVK1dOkydPVuvWrSVJP/zwgz7//HM9+OCDMgxDgwYN0o8//mj6/h1SpL711luy2Wx68cUX1blzZy1btkx79+7V3r17tXTpUj399NPq3r27vL29NWDAAEdEAAAAAOBBbIb5N081ZcoUeXt7a+3aterdu7fCw8MlSa1atVK/fv30008/6Z133tGYMWNUvHhx0/fvkCK1fv36+uKLL+Tl5aX58+erQ4cOql27tmrXrq0nnnhCCxYskJeXlyZOnKj69es7IgIAAAAAT2FIMmwOuFn9xKyxa9cuNWzYUNWqVctxnREjRig8PFyjRo0yff8OKVIlqXfv3oqKitJLL72kKlWqyN/fX/7+/qpSpYp69uypqKgo9e7d21G7BwAAAADchsTERFWoUMH+vZ+fnyTp0qVL9vu8vLzUsGFD/fTTT6bv3yETJx07dkw2m021atXSl19+6YhdAAAAAMD/eGjX0xFKly6t8+fP27/PmOw2JiZGtWrVst9/+fJlXbx40fT9O6STWqlSJXXp0sURmwYAAAAAOFClSpV09OhR+/d16tSRYRiZJsY9efKkNmzYkKdLj+aXQzqpxYoVU+XKlR2xaQAAAADIwpMnOjJbixYtNGrUKMXExKhSpUpq27atQkJCNHr0aB06dEgVKlTQ/PnzdfnyZXXq1Mn0/TukSL377rsVGxvriE0DAAAAAByoS5cuOnHihGJjY1WpUiUFBQVp+vTp6tKli7777jv7evfff7/efvtt0/fvkCK1d+/e6t27t7Zv387svQAAAAAcj06qae666y5NnTo1032PP/64Dh06pCVLlujs2bO666679Pjjj8vb29v0/TukSO3Ro4d27dql1q1b66233lKnTp1UqVIl+fv7O2J3AAAAAACTLFmyRO3bt5eXV+YpjO644w717dvX4ft3SJF6YzU9dOhQDR06NMd1bTabUlNTHREDAAAAgAewyTHnpNrM36RLeOKJJxQeHq6uXbsqMjJSd911V6Hu3yGz+xqGkedbenq6IyIAAAAA8CSGA24eqm7duoqPj9fHH3+sWrVqqVGjRpo6dapDLjeTHYcUqenp6fm6AQAAAACcw44dO/Trr7/qtddeU2hoqH7++We9/PLLCg8P14svvqgff/zRoft3SJEKAAAAAIWKTqqpatWqpTFjxuj48eNasGCBHnvsMaWkpGjWrFlq1aqVKleurH/84x+ZrqdqFopUAAAAAEC2fHx81LFjR33//fc6fvy4PvnkE9199906evSoRowYoTvvvNP8fZq+RWRheElXy7j+sOZiR9zjM42UylYnMEdKCdd/TUmSV5L7TElwrZR7fOR6Nc3P6gimuBbiHscj/aE6VkcwxaarcVZHMEVqgHv8zfJKNP+SEVbxLu0e74fBB85ZHaHAbKnWHgtHTJyEzEqXLq033nhDf/nLXzR48GCNHTvWIadvUqQCAAAAAG7p559/1vTp0/Xtt9/aJ1EKCQkxfT8UqQAAAACAbMXHx+vrr7/WjBkzdPDgQRmGIS8vL7Vu3Vo9evRQx44dTd8nRSoAAAAA18dwX9MkJydr0aJFmjFjhlavXq309HQZhqGqVasqMjJSkZGRKleunMP2T5EKAAAAALALDw/X+fPnZRiGAgMD9fTTT+ull17Sww8/XCj7p0gFAAAA4NoMB02c5KHd2XPnzunBBx/USy+9pGeffVbBwcGFun+Xnq71wIEDGj9+vCIjI1W7dm35+PjIZrNp1KhRt3zsmjVr1K5dO4WGhqpIkSKqWbOm3nnnHV26dKkQkgMAAACAc9q3b59++ukn9ezZs9ALVMnFO6lffPGFxo4dm+/H/fOf/9Qbb7whm82mhx56SGXLltWmTZv0/vvv67vvvtPmzZsVGhrqgMQAAAAAHMJDu56OUKNGDUv379Kd1Fq1amnAgAH65ptvtG/fPnXr1u2Wj9m1a5fefPNNeXt7a9myZdqwYYO+/fZbHT58WC1atNCBAwf08ssvF0J6AAAAAMDNXLqT2qtXr0zfe3nduub+4IMPZBiGevToobZt29rvDwwM1LRp01SlShV999132r9/v2rWrGl6ZgAAAAAOQCfVbbh0JzW/kpOTtWzZMknS888/n2V5xYoV1bhxY0nSwoULCzUbAAAAAMDDitSDBw/qypUrkqR69eplu07G/bt27Sq0XAAAAAAKxmaYf4M1XHq4b35FR0dLkkqUKKGiRYtmu0758uUzrZsXEREROS6Lj4+XLYd9AQAAADAJRaXb8KhOamJioiQpKCgox3Uypli+ePFioWQCAAAAAPyPR3VSHSUuLi7HZRERETrJtVcBAAAAh2J4rvvwqCI1Y4jv5cuXc1zn0n8LymLFihVKJgAAAADIq+XLl+uXX37Rzp07tXPnTsXHx0uSYmNjcz0N0ZV4VJFaqVIlSdL58+eVmJiY7XmpsbGxmdYFAAAA4AI8pJP6/PPP68KFC1bHcCiPOie1Ro0aCgwMlCTt2LEj23Uy7q9bt26h5QIAAACAvHjqqaf0/vvva+XKlTp16pTVcRzCozqpfn5+at++vebNm6fZs2frkUceybT86NGj2rJliyTpySeftCIiAAAAgNvhIZ3Ur776yuoIDudRnVRJGjRokGw2m6ZPn66VK1fa779y5Yp69uyptLQ0derUSTVr1rQwJQAAAID84Dqp7sOlO6lRUVHq16+f/fvDhw9LkiZPnqylS5fa71+4cKHCw8MlXR/G++mnn+qNN95Qu3bt1LRpU5UpU0abNm1SfHy8atSooUmTJhXuEwEAAAAASHLxIvXixYvatm1blvvj4uIyXRYmKSkp0/LXX39dtWvX1qeffqpffvlFly9fVoUKFfT222/r7bffznZCJQAAAABOypBjhvvSTbWESxepzZo1k2Hc3iunZcuWatmypcmJAAAAALiT+Pj4XC/tcmNzDOZw6SIVAAAAACQ5fddz4MCBWrx4cb4f9+WXX6pJkyYOSOS8KFIBAAAAIAfh4eGmdEtPnDihAwcO5Ptxly5dKvC+XQ1FKgAAAACX5+yz8c6aNUuzZs2yOoZLoEgtDDYpPTDd6hQFZkuzWR3BFEnXfK2OYArDz/VfU5KkJG+rE5gmLcg9jsnv58KtjmCKtGD3OB4J9xWxOoIpvj1Z3+oIpkgKcY/3Qq8UqxOY56qbvK+nlPK3OkLBebnH7wesR5EKAAAAwPU5eScVeUeRCgAAAMDlOftwX+QdRSoAAAAAuIiRI0dq2bJlWe7v0KGD/Pz8JEl169bVxIkTCzuaaShSAQAAALg+D+mkHj58WNu2bcty/65du+xfBwQEFGYk03lZHQAAAAAAkDczZsyQYRi53tavX291zAKhkwoAAADA9XlIJ9UT0EkFAAAAADgNOqkAAAAAXB5XaXUfFKkAAAAAXB/Dfd0Gw30BAAAAAE6DTioAAAAAl2aTZHNAJ5UhxNagkwoAAAAAcBp0UgEAAAC4NkOOOSeV81wtQScVAAAAAOA06KQCAAAAcH10Pd0GnVQAAAAAgNOgkwoAAADA5Tlidl9YgyIVAAAAgOujSHUbDPcFAAAAADgNOqkAAAAAXB7Dfd0HnVQAAAAAgNOgkwoAAADA9dFJdRt0UgEAAAAAToNOKgAAAACXxzmp7oMitTAYkvdl129an6ubanUEU3idDLA6gim83eQPcbq/mzwRSbZkm9URTBH3a5jVEUxhc/0/u5Kki3emWx3BFBejKlodwRRGxTSrI+AmXscDrY5gisO9UqyOUGCpv1scwH3+pfB4bvIWDgAAAABwB3RSAQAAALg+Oqlug04qAAAAAMBp0EkFAAAA4PKYOMl9uHQn9cCBAxo/frwiIyNVu3Zt+fj4yGazadSoUdmun56eri1btujdd99VkyZNVKpUKfn6+io0NFStWrXSN998I8Pg1Q0AAAAAVnHpTuoXX3yhsWPH5nn9I0eOqHHjxpKkkJAQ1atXTyVLltSRI0e0Zs0arVmzRnPmzNF3330nPz8/R8UGAAAAYCZDjjknlf6VJVy6k1qrVi0NGDBA33zzjfbt26du3brlur7NZlPz5s21YsUKnTp1Sj/88IPmzJmjX375RevXr1dQUJCWLl2qDz/8sJCeAQAAAADgRi7dSe3Vq1em7728cq+5q1atqrVr12a7rGnTpho0aJCGDh2qr7/+Wu+++65pOQEAAAA4lo3T9tyGSxepZqtTp44kKTY21uIkAAAAAPKFGtVtuPRwX7MdOnRIkhQeHm5xEgAAAADwTHRS/+vKlSsaN26cJKlTp04WpwEAAACQH1yCxn1QpP5Xv379FB0drTvuuEODBw/O12MjIiJyXBYfHy9b0aIFjQcAAAAAHoEiVdLIkSM1c+ZMBQQE6Ntvv1WpUqWsjgQAAAAgP+ikug2PL1LHjBmjd999V/7+/lq4cKH9Oqr5ERcXl+OyiIgInbx0qSARAQAAAMBjeHSROn78eL355pvy8/PTd999pzZt2lgdCQAAAMBt4JxU9+GxReqECRPUv39/e4Havn17qyMBAAAAuF0UqW7DIy9BM2nSJL3yyiv2AvWxxx6zOhIAAAAA5OrUqVP6+uuv9fzzz6tatWoKCAhQYGCgatasqf79+ysmJsbqiKbwuCJ16tSp6tevHwUqAAAA4EZshvk3Z/PGG2+oe/fumjt3rgIDA9WhQwc98sgjOnv2rMaPH69atWpp9erVVscsMJce7hsVFaV+/frZvz98+LAkafLkyVq6dKn9/oULFyo8PFy7d+9W3759ZRiGqlSpovnz52v+/PnZbnvGjBkOzQ4AAAAA+RESEqIRI0aoZ8+eKleunP3+S5cuqXfv3pozZ466dOmi//znPypZsqSFSQvGpYvUixcvatu2bVnuj4uLyzTjblJSkiTp/PnzMozrH4ns379f+/fvz3HbFKkAAACAC3HCzqfZxo0bl+39wcHBmjZtmpYtW6azZ89q2bJl6tq1ayGnM49LD/dt1qyZDMO45a1SpUr5Wj+jkAUAAAAAVxAYGKgaNWpIkmJjYy1OUzAu3UkFAAAAADnqHFIX6l2lpKTYJ04KDw+3NkwBUaQCAAAAQA7i4+MVERGR4/IbTzO00rRp05SQkKAiRYqobdu2VscpEIpUAAAAAK7Pg0/Z++233/TWW29JkoYOHaqyZctanKhgKFILgyF5pdisTlFgJX5xj5eLf6c/rY5gipP7y1gdwRReSa7/u5HB+6p7PJeRz862OoIp3p3zvNURTFH5wz1WRzDFiv9ssTqCKR7u18fqCKY43sylpyXJpPy98VZHMIVf62NWRyiwk+kpUqA1+7bJMcN9bbo+dNaMbunAgQO1ePHifD/uyy+/VJMmTXJcHhcXp8cff1yXLl1Shw4dNGjQoILEdAruUXUAAAAAgBM7ceKEDhw4kO/HXbp0KcdlJ0+eVIsWLXT06FE9+uij+vbbb2Wzuf6H5u7zMRoAAAAAz2U44GaiWbNm5flKIzfe2rRpk+32Tp06pebNm+vgwYNq2bKlFi1aJH9/f3NDW4QiFQAAAABcyOnTp9W8eXPt27dPLVq00OLFixUQEGB1LNMw3BcAAACAy7OlW52gcCQkJKh58+b6448/1KJFCy1ZskRFihSxOpap6KQCAAAAgAs4e/asWrRood9//10tW7Z0ywJVopMKAAAAwB14wBVoevXqpV9//VU2m00hISH6y1/+ku16HTt2VMeOHQs3nIkoUgEAAAC4PEdcgsbZnD17VpJkGIa+/fbbHNerVKkSRSoAAAAAwLHWr19vdYRCQZEKAAAAwPUZHtBK9RBMnAQAAAAAcBp0UgEAAAC4NsNB56TSnLUEnVQAAAAAgNOgkwoAAADA9dH1dBt0UgEAAAAAToNOKgAAAACX5wnXSfUUFKkAAAAAXB+XoHEbDPcFAAAAADgNOqkAAAAAXB7Dfd0HnVQAAAAAgNOgkwoAAADA9dFJdRt0UgEAAAAAToNOKgAAAACXxzmp7oMiFQAAAICLM6R0R1SpVL5WYLgvAAAAAMBp0EkFAAAA4NoMOabpSSPVEhSphcFLSg1OtzpFgZ2vYbM6ginSD5a2OoI5vN3lr6Z7vK4kKaWE6/+eS9KgH7pYHcEcJd3jeBz4qLbVEUxRZd69VkcwxyNWBzCHzT1+PSRJR/eFWR3BFN6j77A6QoGljlpldQS4CYpUAAAAAC6PiZPcB+ekAgAAAACcBp1UAAAAAK7PoJXqLuikAgAAAACchksXqQcOHND48eMVGRmp2rVry8fHRzabTaNGjcrXdiZOnCibzSabzaZevXo5KC0AAAAAR7EZ5t9gDZce7vvFF19o7NixBdrGkSNHNHDgQNlsNhkMEQAAAABcE//Kuw2X7qTWqlVLAwYM0DfffKN9+/apW7du+Xp8enq6IiMjZbPZ9OKLLzooJQAAAAAgr1y6k3rz0Fwvr/zV3GPHjtWmTZs0YcIEnTp1ysxoAAAAAAqJTZLNAaMi3edq7q7FpTupBXHgwAG98847atq0qf7yl79YHQcAAAAAIBfvpN6utLQ0de/eXTabTdOmTZPNxmckAAAAgEtLtzoAzOKRRerHH3+sbdu26Z///KeqVq1a4O1FRETkuCw+Pl62YkULvA8AAAAA8AQeV6T+/vvvGjZsmBo1aqT+/ftbHQcAAACACRxxTiqs4VFFampqqrp37y4vLy999dVX+Z5oKSdxcXE5LouIiNDJy5dM2Q8AAACAbBhyzCVoqHst4VFF6nvvvaeoqCiNHj1aNWrUsDoOAAAAAOAmHlWkLly4UJK0ZMkSLV++PNOymJgYSdKyZcvUrFkzSdL69esLMR0AAACA28ZwX7fhUUVqhs2bN+e47OTJkzp58mQhpgEAAAAAZPCo66Tu3r1bhmFkexs2bJgkqWfPnvb7AAAAALgGm2H+DdbwqCIVAAAAAFzVxYsXNXToULVv315Vq1ZV8eLF5efnpzvuuENPPPGEli1bZnVEU7j0cN+oqCj169fP/v3hw4clSZMnT9bSpUvt9y9cuFDh4eGFng8AAABAIfGAkZCnTp3SqFGjFBwcrFq1aum+++6Tl5eX/vOf/2jx4sVavHix+vXrpwkTJlgdtUBcuki9ePGitm3bluX+uLi4TJeFSUpKKsxYAAAAAGC6sLAwbd26VfXq1ZOPT+ZSbt26dXrsscc0ceJEdejQQY8++qhFKQvOpYf7NmvWLMdzTG+8VapU6ZbbGj58uAzD0Jdffun44AAAAABMZUs3/+ZsgoOD9cADD2QpUCXpkUceUZcuXSRJq1atKuxopnLpTioAAAAASPKI4b63klG8+vv7W5ykYFy6kwoAAAAAkLZv3665c+fKZrPp8ccftzpOgdBJBQAAAOD6HNRIjY+PV0RERI7Lb5wLpzC9++67OnbsmK5evaro6Ght375dfn5+GjdunB588EFLMpmFIrUwpEvel1y/ae2baLM6gilSa1+yOoIp0k4EWh3BHO7xspIk+SS6/u+5JN370CGrI5jit43VrI5givKr3WPyv1bjN1kdwRRzvmhldQRTXKiZZnUE0/iFXbE6ginCpgdYHaHA4pIMKdjqFJ5j8eLF2rNnj/374OBgjRkzRi+99JKFqcxBkQoAAADA5dkcdE5qeHi4Kd3SgQMHavHixfl+3JdffqkmTZpkuX/37t2Srl/x5MCBA/rss8/Up08fzZkzR4sWLVLRokULGtkyFKkAAAAA4GAnTpzQgQMH8v24S5dyHwVYrFgx1a9fX998841KlCihiRMnasSIEfrkk09uN6rl3GNsGgAAAADPZej67L6m38yLOGvWrDxdPvPmW5s2bfK8jx49ekiSFi5caF5wC9BJBQAAAOD6nPC6poUtKChIknTq1CmLkxQMnVQAAAAAcANr166VJFWvXt3iJAVDkQoAAADAxRmyGebfHHZdm9s0e/Zs7dy5M8v9hmFowYIFGjJkiCSpT58+hR3NVAz3BQAAAAAXsGrVKr3wwguKiIjQvffeqxIlSujMmTPav3+/jh49Kkn661//SpEKAAAAAJZz0CVonEnv3r1VvHhxbdmyRVFRUTpz5ox8fX0VERGh7t27q1evXtlersbVUKQCAAAAgAto3LixGjdubHUMh6NIBQAAAOD6PKCT6imYOAkAAAAA4DTopAIAAABwfVwn1W1QpAIAAABweTaG+7oNhvsCAAAAAJwGnVQAAAAAro9OqtugkwoAAAAAcBp0UgEAAAC4NkOO6aTSnLUEnVQAAAAAgNOgkwoAAADA9XFOqtugSAUAAADg+rhOqttguC8AAAAAwGnQSQUAAADg8mwM93UbdFIBAAAAAE6DTioAAAAA10cn1W1QpBYCmyTvJJvVMQrsWnia1RFMYVz1tTqCKXyTXf81JUmpge4zy4F3snsMTok+H2J1BFN4pbjJ70gRb6sjmOKPS+FWRzBFarDVCcxh+LnPP/PJV/ysjmCKM7Vd//+T9I3u8XcX1qNIBQAAAODiDCndER++uM8HOq7EPT72BwAAAAC4BTqpAAAAAFwf56S6DYpUAAAAAK7NkGOKVOpeS7j0cN8DBw5o/PjxioyMVO3ateXj4yObzaZRo0bd8rHp6emaOXOmWrZsqdKlS8vf31/h4eFq3ry5Jk6cWAjpAQAAAAA3c+lO6hdffKGxY8fm+3EXLlxQhw4dtHHjRhUrVkyNGjVSiRIldPz4ce3atUsXL15Uv379HJAYAAAAgEMw3NdtuHSRWqtWLQ0YMEB16tRR3bp19f777+tf//pXro8xDEMdO3bUxo0b1bdvX33yyScKDv7ffPLJycn69ddfHR0dAAAAAJANly5Se/Xqlel7L69bj16ePn261q9fr0cffVSTJk3KstzPz0/16tUzLSMAAACAQuCQS9DACi59TurtGDdunCTprbfesjgJAAAAAOBmLt1Jza8///xTe/bskbe3txo1aqQjR47o22+/VUxMjIKDg9WwYUM98cQT8vPzszoqAAAAgPww0q1OAJN4VJGaca5pqVKl9OWXX+rNN99USkpKpnWqVKmihQsX6t5777UiIgAAAIDbwcRJbsOjhvueOXNGknT27Fn1799fTzzxhH777TclJiZq69atatiwoY4cOaI2bdrY182LiIiIHG/x8fGOejoAAAAA4HY8qkg1/vvpSmpqqh588EHNmzdPtWrVUnBwsB544AGtXr1aZcuWVXx8PNdKBQAAAFxJumH+DZbwqCK1aNGi9q/79u2b7fKuXbtKktasWZPn7cbFxeV4Cw8PL3hwAAAAAPAQHnVOapUqVbL9Ort1GKYLAAAAuArDQeek0k21gkd1UqtXr27vpiYkJGS7Tsb9wcHBhZYLAAAAAHCdRxWpPj4+6tixo6Sch/OuXr1aktSgQYPCigUAAACgIAxd76SafrP6iXkmjypSJWnw4MHy9fXV1KlTtXTp0kzLPv74Y23evFne3t7661//alFCAAAAAPBcLn1OalRUlPr162f//vDhw5KkyZMnZypAFy5caJ/AqGbNmpo6dapeeuklPf7446pXr54qVaqk33//Xfv375e3t7e++OIL1a5du3CfDAAAAIDbx3VS3YZLF6kXL17Utm3bstyfMbNuhqSkpEzLu3fvrrvvvlujR4/Wpk2btGfPHpUqVUrPPPOMBgwYwFBfAAAAwNWkp1udwBKXLl3Svffeq+joaElSbGysIiIiLE5VMC5dpDZr1sx+7dP8ql+/vubPn29yIgAAAAAoPG+99ZZiYmKsjmEqjzsnFQAAAIAbcsTESU5u9erVmjRpktvNp0ORCgAAAAAu5uLFi+rZs6cqV66sDz/80Oo4pnLp4b4AAAAAIMklOp9meu211xQXF6c1a9YoKCjI6jimopMKAAAAAC5k2bJlmj59unr37q3mzZtbHcd0dFILgyHZ3GCysbr3HbY6gin+WF3d6gimMLytTmAOo4T7fOqZ7uMezyVtdajVEUyRXtY9jsfRJ2xWRzDF2fm1rI5giqv3X7E6gjmS3ORNRFLAIX+rI5jinZ7/tjpCgb0y44qkYOsCpLvH3/1bOXfunHr37q3y5cvr448/tjqOQ1CkAgAAAHB5huGYrlB8fHyul3S58dKXheGVV15RfHy8VqxYoWLFihXqvgsLRSoAAAAAONjAgQO1ePHifD/uyy+/VJMmTSRJCxYs0OzZs9WjRw+1adPG7IhOgyIVAAAAgGszDMcM9zUMhd8Rbkq39MSJEzpw4EC+H3fp0iVJUkJCgv7yl7/ojjvu0JgxYwqcx5lRpAIAAACAg82aNUuzZs267cdv3rxZp06dUkREhDp27Jjjes8884z8/f0VGRmpyMjI296flShSAQAAALg+D7kETVxcXK6d3Z9//lmS1KxZs0JKZD6KVAAAAABwch07dpSRSyFus12fDT42NjbXiZ5cAUUqAAAAANeX7gbXfIQkycvqAAAAAAAAZKCTCgAAAMD1ecg5qZ6AIhUAAACAyzM8fLhvbueruhqG+wIAAAAAnAadVAAAAACuz406iZ6OTioAAAAAwGnQSQUAAADg2gxJ6Q7opNKctQSdVAAAAACA06CTCgAAAMDFGZLhiNl9aaVagSIVAAAAgMszHDHcF5ZguC8AAAAAwGnQSQUAAADg+hwy3BdWoJMKAAAAAHAadFIBAAAAuDzOSXUfdFIBAAAAAE6DTioAAAAA18c5qW7DZhgGfXEH8vPzU0pqqnyCi1kdpcB8AlKtjmCK1Gtu8tmMzeoA5jDcaTyHm7w32tzkebjNa8tNnofNPd5CZPi5yb9NbvI0JMmW6h5viEUDr1gdocDOn06Rj7evkpOTC3W/EREROn78uPxVxPRtJ+mqypUrp7i4ONO3jZy5yX/rzsvX11eSVKZYsMP2ER8fL0kKDw932D7cip9jN8/xcC4cD+fDMXEuHA/nwvFwPoV3TBz3v2JhueR9yv6/b2EKCwtz6e0jKzqpbiAiIkKS+ITHSXA8nAvHw/lwTJwLx8O5cDycD8cEKHxuMogIAAAAAOAOKFIBAAAAAE6DIhUAAAAA4DQoUgEAAAAAToMiFQAAAADgNChSAQAAAABOg0vQAAAAAACcBp1UAAAAAIDToEgFAAAAADgNilQAAAAAgNOgSAUAAAAAOA2KVAAAAACA06BIBQAAAAA4DYpUAAAAAIDToEh1YfPmzVOzZs1UsmRJBQUF6b777tNHH32klJQUq6N5lJSUFK1du1ZvvfWW6tevrxIlSsjX11dhYWHq0KGDli1bZnVEjzdw4EDZbDbZbDaNGjXK6jgeKzk5WePGjVOTJk0UEhKigIAARUREqG3btpo7d67V8TzKsWPH9Morr6hGjRoqUqSIAgICVLlyZXXv3l179uyxOp7bOXDggMaPH6/IyEjVrl1bPj4+ef57tGbNGrVr106hoaEqUqSIatasqXfeeUeXLl0qhOTuK7/HJD09XVu2bNG7776rJk2aqFSpUvL19VVoaKhatWqlb775RoZhFPKzANyYAZf06quvGpIMHx8fo3Xr1sZTTz1llChRwpBkNGnSxLhy5YrVET3G6tWrDUmGJCMsLMxo37690blzZ6NWrVr2+/v06WOkp6dbHdUj/fTTT4aXl5dhs9kMScbIkSOtjuSRYmNjjbvvvtuQZISGhhqPPfaY8eyzzxqNGjUyAgMDjU6dOlkd0WP8/PPPRtGiRQ1JRrly5YwOHToYTz75pFG5cmX7+8q3335rdUy3kvGeffPtVn+PxowZY0gybDab8fDDDxvPPPOMERYWZkgyatSoYZw+fbqQnoH7ye8xOXTokH2dkJAQo3Xr1sazzz5r1K9f337/Y489ZiQlJRXyMwHcE0WqC1q4cKEhyQgODjZ27txpv//06dNG7dq1DUnGm2++aWFCz7J27VqjU6dOxsaNG7MsmzNnjuHt7W1IMmbOnGlBOs92+fJlo1q1aka5cuWMjh07UqRa5MqVK0bNmjUNScbw4cON5OTkTMsvX75s7Nq1y5pwHujee++1f3h247FIS0szhgwZYkgySpQoYVy9etXClO5l6tSpxoABA4xvvvnG2Ldvn9GtW7db/j2KiooybDab4e3tbSxfvtx+/+XLl40WLVoYkvhwpwDye0z+85//GM2bNzdWrFhhpKamZlq2fv16IygoyJBkjBgxojDiA26PItUFZXxqN2rUqCzLNm3aZEgy/P39jfPnz1uQDjfr2bOnIclo0aKF1VE8Tv/+/Q1JxrJly4zu3btTpFpk6NCh9qII1kpISLB3fU6dOpVleWpqqlGkSBFDkhEVFWVBQs+Ql79HzzzzjCHJ6NWrV5ZlMTExhpeXlyHJ2LdvnyOjeoyCvkeMHDnSkGRUrVrV5GSAZ+KcVBdz/Phxbd++XZL0/PPPZ1nepEkTlS9fXklJSVq+fHlhx0M26tSpI0mKjY21OIlnWb9+vcaPH68XX3xR7dq1szqOx0pJSdEXX3whSXrrrbcsTgN/f/88rxsaGurAJMhNcnKyfT6D7N7rK1asqMaNG0uSFi5cWKjZkD3e6wFzUaS6mF27dkmSQkJCVLly5WzXqVevXqZ1Ya1Dhw5JksLDwy1O4jkuXbqkl156SWXLltVnn31mdRyPFhUVpYSEBN1xxx2688479dtvv2nEiBHq27evBg0apGXLlik9Pd3qmB4jODhYDz30kCRpyJAhmSbaS09P1/Dhw3X16lW1bdtW5cuXtyqmxzt48KCuXLki6X/v6Tfjvd658F4PmMvH6gDIn+joaElShQoVclwn4x+LjHVhnZMnT2rGjBmSpE6dOlkbxoMMGDBA0dHRWrhwoUqWLGl1HI/266+/SpIiIiI0aNAgffTRR5lmwBw9erTq1KmjRYsW5fp3DeaZOnWq2rVrpylTpmjZsmWqV6+evL29tWvXLh0/flzdunXT559/bnVMj5bx/l2iRAkVLVo023V4r3ceV65c0bhx4yTxXg+YhU6qi0lMTJQkBQUF5bhOcHCwJOnixYuFkgnZS01NVdeuXXXhwgXVrl1bffv2tTqSR1i1apUmT56sLl26qGPHjlbH8XhnzpyRdL3bM3r0aPXr108HDhzQhQsXtHr1alWvXl27du1S+/btuXxWIalRo4a2bt2q1q1b6/jx4/r++++1YMECRUdH684771SzZs1UrFgxq2N6NN7rXUu/fv0UHR2tO+64Q4MHD7Y6DuAWKFIBB3n55Ze1du1alSpVSvPnz5efn5/VkdzehQsX1LNnT5UuXVrjx4+3Og4ke9c0JSVFzz33nD7//HNVr15dxYoVU8uWLbV69WoFBATo999/15w5cyxO6xl++ukn1a5dW7///rtmz56tkydP6uzZs1qyZIlSUlLUs2dP9ezZ0+qYgEsYOXKkZs6cqYCAAH377bcqVaqU1ZEAt0CR6mIyhv1cvnw5x3UyLvDNJ+HWefXVVzVt2jSVLFnS3i2C47322muKi4vT559/zqQvTuLGoYrZjSaoUKGC2rdvL0las2ZNoeXyVOfPn9eTTz6p06dPa8GCBXruuedUtmxZlSxZUo899phWrlypwMBAffXVV1q3bp3VcT0W7/WuYcyYMXr33Xfl7++vhQsX2iezAlBwnJPqYipVqiQp99njMpZlrIvC9eabb2rcuHEqUaKEVq1aZZ/xD463cOFC+fj4aOLEiZo4cWKmZfv375ckTZs2TWvWrFFYWBidu0JQpUqVbL/Obp34+PhCyeTJli1bptOnT6tq1apq2LBhluVVqlRRw4YNtW7dOq1Zs0aPPPKIBSmR8f59/vx5JSYmZnteKu/11ho/frzefPNN+fn56bvvvlObNm2sjgS4FYpUF5NR8Jw5c0bR0dHZzvC7Y8cOSVLdunULNRukgQMHasyYMSpevLhWrVqV46yMcJzU1FRt2LAhx+UxMTGKiYlRxYoVCzGV56pbt65sNpsMw1BCQkK2M8YmJCRI+t85dnCcY8eOScq9+1a8eHFJ0tmzZwslE7KqUaOGAgMDdeXKFe3YsSPbDwt4r7fOhAkT1L9/f3uBmjEaBIB5GO7rYiIiIlS/fn1J0uzZs7Ms37x5s2JjY+Xv78+1IQvZoEGD9PHHH6t48eJavXq1/Tih8Jw/f16GYWR76969u6Tr5w8ZhqGYmBhrw3qIsLAwNWnSRFL2w3lTUlLsHyo0aNCgULN5onLlykm6PrLgwoULWZanpKQoKipKknK8zBkcz8/Pz174ZPdef/ToUW3ZskWS9OSTTxZqNk83adIkvfLKK/YC9bHHHrM6EuCWKFJdUMbMcR9++KH9nwnpene1X79+kqRXXnnF/mk4HG/IkCEaPXq0SpQoQYEK3GTYsGGSpA8++EA///yz/f7U1FS9+eabOnLkiIoWLaoePXpYFdFjtG3bVkFBQbp69ap69+5tP69RkpKTk/X666/r2LFj8vX11dNPP21hUgwaNEg2m03Tp0/XypUr7fdfuXJFPXv2VFpamjp16qSaNWtamNKzTJ06Vf369aNABQqBzbjxgnVwGa+++qrGjRsnX19ftWjRQkFBQVq7dq3Onz+vxo0ba/Xq1SpSpIjVMT3C4sWL9cQTT0i6fnH1e+65J9v1QkND9cknnxRmNNwgMjJSM2fO1MiRIzVkyBCr43icUaNGaejQofLx8VGDBg0UFhamqKgoxcTEqEiRIpo3bx5D5grJrFmz1KNHD6Wmpqp06dKqX7++fH19tWPHDh0/flxeXl6aMGGCXn75Zaujuo2oqCj7h8iSdPjwYSUkJCgiIsLe3Zaun1cfHh5u//6f//yn3njjDdlsNjVt2lRlypTRpk2bFB8frxo1amjz5s1MEneb8ntMdu/erbp168owDNWsWTPbc7ozZFwfHUABGHBZc+fONR5++GGjWLFiRpEiRYxatWoZH374oZGUlGR1NI8yffp0Q9ItbxUrVrQ6qkfr3r27IckYOXKk1VE81g8//GC0bdvWCAkJMXx9fY3y5csbkZGRxr59+6yO5nF2795tREZGGlWqVDH8/f0NPz8/o2LFisYLL7xgbNu2zep4bmfdunV5ep+Ijo7O8tjVq1cbbdq0MUJCQgx/f3+jWrVqxttvv21cvHix8J+IG8nvMcnr+vxrDZiDTioAAAAAwGlwTioAAAAAwGlQpAIAAAAAnAZFKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSoAAAAAwGlQpAIAAAAAnAZFKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSoAwKnZbDbZbDarYwAAgEJCkQoAAAAAcBoUqQAAAAAAp0GRCgAAAABwGhSpAIACuXLlij777DM1adJEJUuWlL+/vypWrKjHH39cs2fPzrLuhx9+qLp166po0aIKDAzUPffcoyFDhujcuXP52u+tzlVt1qyZbDab1q9fn+P9P//8s9q3b69SpUqpaNGiatq0qTZt2mRfd+XKlWrRooVKliyp4OBgtWrVSlFRUVn2FRMTI5vNpkqVKskwDE2ZMkX333+/goKCVLx4cbVu3Vpbt27N1/MDAMBT2QzDMKwOAQBwTbGxsWrTpo327t2rwMBANW7cWKVKldLx48f166+/qkSJEoqJiZEknT17Vi1atNDu3btVrFgxNWvWTL6+vtqwYYMSEhJUuXJl/fjjj6pUqVKmfWQUoje/XeV0f4ZmzZppw4YNWrdunZo1a5bl/gEDBuizzz5T7dq1Vb16dR04cEC7d++Wv7+/fvzxR+3atUv9+/fXAw88oIiICO3evVsHDx5UcHCwdu3apTvvvNO+zZiYGFWuXFkVK1ZUs2bNNHv2bD300EMKDQ21P87f318bNmxQw4YNC/hTBwDAzRkAANyGtLQ0o169eoYko3Xr1sapU6cyLb969aqxbNky+/fPPvusIclo2LChkZCQYL8/MTHRaNu2rSHJaNSoUZb9SDKye7vK6f4MTZs2NSQZ69aty/Z+m81m/Otf/8q07I033jAkGTVq1DCCg4ONNWvW2JelpqYanTp1MiQZvXr1yvS46Ohoe56KFSsaBw4cyPS4l156yf5zAgAAuWO4LwDgtixZskQ7duxQeHi4vvvuO5UuXTrT8oCAALVr106SdOzYMc2bN082m01TpkxRqVKl7OsFBwdr6tSpCggI0JYtW7Rly5ZCyf/000+ra9eume575513JEkHDhzQX/7yF7Vo0cK+zNvbW4MHD5YkrV27Nsftjh8/XtWrV8/0uPfee0+StGHDBqWkpJj2HAAAcEcUqQCA27Jy5UpJ0vPPP6/g4OBc1924caPS09NVp04d3XvvvVmWlytXTo8++qgkad26deaHzUZGAX2jkJAQewGd3fJq1apJkk6cOJHtNn18fNSmTZss94eFhalkyZJKSkrSmTNnChIbAAC3R5EKALgtR48elSTVrFnzluseP35cklS5cuUc16latWqmdR2tQoUK2d6fUXBnt7xo0aKSpKSkpGwfGx4eLl9f32yXFStWTJJ07dq1fGcFAMCTUKQCANxSenp6rsu9vHJ/C7zVcrMeAwAAMuPdFABwWzI6jfv377/luuXKlZMkHTlyJMd1MpZlrHsrGR3LxMTEbJdndHoBAIBroUgFANyWjHMv//3vf+vy5cu5rvvwww/Ly8tLu3fv1p49e7Isj4+Pt5/j+sgjj+Rp/xnF7L59+7Is+/XXXxUbG5un7QAAAOdCkQoAuC0dOnRQnTp1dOLECT3zzDNZJgS6du2aVqxYIel61/WZZ56RYRjq27dvpnUvX76sPn366Nq1a2rUqJEaNWqUp/23bNlSkjRixIhM54jGxMSoe/fuOV4/FQAAODcfqwMAAFyTl5eXFi5cqEcffVQrVqxQhQoV1KRJE5UqVUrHjx/Xnj17VKJECcXExEiSJkyYoP3792vbtm2qWrWqHnnkEfn4+GjDhg06ffq0KleurG+++SbP+x88eLDmz5+v5cuXq3r16qpfv75Onz6t7du3q3HjxmrUqFGhXc4GAACYh04qAOC2VaxYUTt27NDo0aN1zz33aOvWrVqwYIGOHj2qpk2bavTo0fZ1S5UqpS1btuiDDz5Q5cqVtWrVKi1dulShoaEaPHiwdu7cqUqVKuV535UrV9aWLVv01FNPKTExUUuXLtWff/6pd955R8uXL89xll0AAODcbAbjoQAAAAAAToJOKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSoAAAAAwGlQpAIAAAAAnAZFKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSoAAAAAwGlQpAIAAAAAnAZFKgAAAADAaVCkAgAAAACcBkUqAAAAAMBpUKQCAAAAAJwGRSoAAAAAwGlQpAIAAAAAnMb/Aw8WK+T4+bOmAAAAAElFTkSuQmCC" alt="Heatmap of a generated rank-2 matrix" style="display: block; width: 100%;">
+        <figcaption>Figure 1: Synthetic rank-2 matrix</figcaption>
+      </figure>
+    </div>
+    <p>In HTML output, this figure is a useful asset-inlining check: a self-contained render should embed the generated PNG directly in the page instead of linking to a file under <code>.calepin/</code>.</p>
+    <h3 id="fitting-a-rank-2-model">Fitting a rank-2 model</h3>
+    <p>The loss is squared error on observed ratings plus a small penalty that keeps the latent vectors from growing too large:</p>
+    <div class="calepin-math-display"><math display="block"><mi>L</mi><mo>=</mo><msub><mo>∑</mo><mrow><mo>(</mo><mi>i</mi><mo>,</mo><mi>j</mi><mo>)</mo><mo>∈</mo><mi>Ω</mi></mrow></msub><msup><mrow><mo>(</mo><msub><mi>r</mi><mrow><mi>i</mi><mo>,</mo><mi>j</mi></mrow></msub><mo>-</mo><msub><mover><mi>R</mi><mo>^</mo></mover><mrow><mi>i</mi><mo>,</mo><mi>j</mi></mrow></msub><mo>)</mo></mrow><mn>2</mn></msup><mo>+</mo><mi>λ</mi><mrow><mo>(</mo><msub><mo>∑</mo><mi>i</mi></msub><msup><mrow><mo>||</mo><msub><mi>u</mi><mi>i</mi></msub><mo>||</mo></mrow><mn>2</mn></msup><mo>+</mo><msub><mo>∑</mo><mi>j</mi></msub><msup><mrow><mo>||</mo><msub><mi>v</mi><mi>j</mi></msub><mo>||</mo></mrow><mn>2</mn></msup><mo>)</mo></mrow></math></div>
+    <p>Here is a simple stochastic gradient descent fit.</p>
+    <div class="sourceCode" data-lang="python">
+      <pre><code data-lang="python">random.<span class="calepin-syntax-function">seed</span>(<span class="calepin-syntax-number">12</span>)<br><br>rank = <span class="calepin-syntax-number">2</span><br>learning_rate = <span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">025</span><br>regularization = <span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">02</span><br>epochs = <span class="calepin-syntax-number">2400</span><br><br>mu = <span class="calepin-syntax-function">sum</span>(value for _<span class="calepin-syntax-operator">,</span> _<span class="calepin-syntax-operator">,</span> value in observed) <span class="calepin-syntax-operator">/</span> <span class="calepin-syntax-function">len</span>(observed)<br>user_factors = [<br>    [random.<span class="calepin-syntax-function">uniform</span>(<span class="calepin-syntax-operator">-</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">35</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">35</span>) for _ in <span class="calepin-syntax-function">range</span>(rank)]<br>    for _ in users<br>]<br>item_factors = [<br>    [random.<span class="calepin-syntax-function">uniform</span>(<span class="calepin-syntax-operator">-</span><span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">35</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">35</span>) for _ in <span class="calepin-syntax-function">range</span>(rank)]<br>    for _ in items<br>]<br><br>def <span class="calepin-syntax-function">dot</span>(<span class="calepin-syntax-parameter">left</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">right</span>):<br>    return <span class="calepin-syntax-function">sum</span>(a <span class="calepin-syntax-operator">*</span> b for a<span class="calepin-syntax-operator">,</span> b in <span class="calepin-syntax-function">zip</span>(left<span class="calepin-syntax-operator">,</span> right))<br><br>def <span class="calepin-syntax-function">predict</span>(<span class="calepin-syntax-parameter">i</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-parameter">j</span>):<br>    return mu <span class="calepin-syntax-operator">+</span> <span class="calepin-syntax-function">dot</span>(user_factors[i]<span class="calepin-syntax-operator">,</span> item_factors[j])<br><br>def <span class="calepin-syntax-function">rmse</span>():<br>    total = <span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">.</span><span class="calepin-syntax-number">0</span><br>    for i<span class="calepin-syntax-operator">,</span> j<span class="calepin-syntax-operator">,</span> value in observed:<br>        total += (value <span class="calepin-syntax-operator">-</span> <span class="calepin-syntax-function">predict</span>(i<span class="calepin-syntax-operator">,</span> j)) <span class="calepin-syntax-operator">*</span><span class="calepin-syntax-operator">*</span> <span class="calepin-syntax-number">2</span><br>    return math.<span class="calepin-syntax-function">sqrt</span>(total <span class="calepin-syntax-operator">/</span> <span class="calepin-syntax-function">len</span>(observed))<br><br>checkpoints = []<br>for epoch in <span class="calepin-syntax-function">range</span>(epochs <span class="calepin-syntax-operator">+</span> <span class="calepin-syntax-number">1</span>):<br>    if epoch <span class="calepin-syntax-operator">in</span> (<span class="calepin-syntax-number">0</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">25</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">100</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">400</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">1200</span><span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-number">2400</span>):<br>        checkpoints.<span class="calepin-syntax-function">append</span>((epoch<span class="calepin-syntax-operator">,</span> <span class="calepin-syntax-function">rmse</span>()))<br>    random.<span class="calepin-syntax-function">shuffle</span>(observed)<br>    for i<span class="calepin-syntax-operator">,</span> j<span class="calepin-syntax-operator">,</span> value in observed:<br>        error = value <span class="calepin-syntax-operator">-</span> <span class="calepin-syntax-function">predict</span>(i<span class="calepin-syntax-operator">,</span> j)<br>        old_user = user_factors[i][<span class="calepin-syntax-operator">:</span>]<br>        old_item = item_factors[j][<span class="calepin-syntax-operator">:</span>]<br>        for d in <span class="calepin-syntax-function">range</span>(rank):<br>            user_factors[i][d] += learning_rate <span class="calepin-syntax-operator">*</span> (<br>                error <span class="calepin-syntax-operator">*</span> old_item[d] <span class="calepin-syntax-operator">-</span> regularization <span class="calepin-syntax-operator">*</span> old_user[d]<br>            )<br>            item_factors[j][d] += learning_rate <span class="calepin-syntax-operator">*</span> (<br>                error <span class="calepin-syntax-operator">*</span> old_user[d] <span class="calepin-syntax-operator">-</span> regularization <span class="calepin-syntax-operator">*</span> old_item[d]<br>            )<br><br>for epoch<span class="calepin-syntax-operator">,</span> value in checkpoints:<br>    <span class="calepin-syntax-function">print</span>(f<span class="calepin-syntax-operator">"</span>epoch {epoch:4d}: observed RMSE = {value:.3f}<span class="calepin-syntax-operator">"</span>)</code></pre>
+    </div>
+    <div class="cell-output cell-output-stdout">
+      <pre><code>epoch    0: observed RMSE = 1.755<br>epoch   25: observed RMSE = 0.463<br>epoch  100: observed RMSE = 0.270<br>epoch  400: observed RMSE = 0.127<br>epoch 1200: observed RMSE = 0.056<br>epoch 2400: observed RMSE = 0.056</code></pre>
+    </div>
+    <aside class="margin-figure">
+      <figure>
+        <table>
+          <tr>
+            <td><strong>Item</strong></td>
+            <td>factor 1</td>
+            <td>factor 2</td>
+          </tr>
+          <tr>
+            <td>Linear algebra</td>
+            <td>1.41</td>
+            <td>−0.73</td>
+          </tr>
+          <tr>
+            <td>Optimization</td>
+            <td>1.37</td>
+            <td>−0.03</td>
+          </tr>
+          <tr>
+            <td>Sci-fi</td>
+            <td>−1.26</td>
+            <td>−0.86</td>
+          </tr>
+          <tr>
+            <td>Cooking</td>
+            <td>−0.73</td>
+            <td>1.27</td>
+          </tr>
+        </table>
+        <figcaption>Table 1: Learned item factors</figcaption>
+      </figure>
+    </aside>
+    <p>The margin table is computed from the trained model. The exact coordinate system is arbitrary, but nearby items have similar factor vectors.</p>
+    <h3 id="completing-the-matrix">Completing the matrix</h3>
+    <p>The fitted model can now predict the missing ratings.</p>
+    <div class="sourceCode" data-lang="python">
+      <pre><code data-lang="python">completed = []<br>for i<span class="calepin-syntax-operator">,</span> row in <span class="calepin-syntax-function">enumerate</span>(ratings):<br>    out = []<br>    for j<span class="calepin-syntax-operator">,</span> value in <span class="calepin-syntax-function">enumerate</span>(row):<br>        out.<span class="calepin-syntax-function">append</span>(value if value <span class="calepin-syntax-operator">is</span> <span class="calepin-syntax-operator">not</span> None else <span class="calepin-syntax-function">predict</span>(i<span class="calepin-syntax-operator">,</span> j))<br>    completed.<span class="calepin-syntax-function">append</span>(out)<br><br><span class="calepin-syntax-function">show_matrix</span>(completed)</code></pre>
+    </div>
+    <div class="cell-output cell-output-stdout">
+      <pre><code>          Line  Opti  Sci-  Cook<br> Ada       5.0   4.0   3.0   1.0<br> Ben       4.0   2.9   4.4   1.0<br>  Cy       1.0   1.0   5.0   4.0<br> Dee       0.5   1.0   4.0   5.0<br> Eli       5.0   5.0   1.0   2.1</code></pre>
+    </div>
+    <p>The same fitted object can also list only the originally missing entries.</p>
+    <div class="sourceCode" data-lang="python">
+      <pre><code data-lang="python">for i<span class="calepin-syntax-operator">,</span> row in <span class="calepin-syntax-function">enumerate</span>(ratings):<br>    for j<span class="calepin-syntax-operator">,</span> value in <span class="calepin-syntax-function">enumerate</span>(row):<br>        if value <span class="calepin-syntax-operator">is</span> None:<br>            <span class="calepin-syntax-function">print</span>(f<span class="calepin-syntax-operator">"</span>{users[i]:>3} -> {items[j]:&lt;14} {<span class="calepin-syntax-function">predict</span>(i<span class="calepin-syntax-operator">,</span> j):.2f}<span class="calepin-syntax-operator">"</span>)</code></pre>
+    </div>
+    <div class="cell-output cell-output-stdout">
+      <pre><code>Ada -> Sci-fi         3.03<br>Ben -> Optimization   2.95<br>Ben -> Sci-fi         4.43<br>Dee -> Linear algebra 0.50<br>Eli -> Optimization   5.02<br>Eli -> Cooking        2.10</code></pre>
+    </div>
+    <h3 id="what-to-check">What to check</h3>
+    <p>Matrix factorization is useful because it shares information across rows and columns. But this sharing is also a modeling assumption. A practical workflow should check prediction error on held-out observed entries, tune the rank <span class="calepin-math-inline"><math><mi>k</mi></math></span>, and inspect whether the completed matrix makes domain sense. Calepin is useful here because the prose, the fitted model, and the diagnostics all live in the same executable document.</p>
+
+</main>
+<script>
+(function () {
+  const article = document.querySelector(".calepin-tufte");
+  if (!article) {
+    return;
+  }
+
+  const endnotes = article.querySelector('section[role="doc-endnotes"]');
+  if (!endnotes) {
+    return;
+  }
+
+  const notes = new Map(
+    Array.from(endnotes.querySelectorAll("li[id]")).map((note) => [note.id, note])
+  );
+
+  article.querySelectorAll('a[role="doc-noteref"][href^="#"]').forEach((ref) => {
+    const targetId = decodeURIComponent(ref.getAttribute("href").slice(1));
+    const source = notes.get(targetId);
+    if (!source) {
+      return;
+    }
+
+    const note = document.createElement("span");
+    note.className = "sidenote tufte-generated-sidenote";
+    note.dataset.noteRef = ref.textContent.trim();
+    note.innerHTML = source.innerHTML;
+
+    const backlink = note.querySelector('[role="doc-backlink"]');
+    if (backlink) {
+      backlink.remove();
+    }
+
+    ref.insertAdjacentElement("afterend", note);
+  });
+
+  endnotes.hidden = true;
+})();
+
+</script>
+</body>
+</html>

--- a/starters/tufte_starter.typ
+++ b/starters/tufte_starter.typ
@@ -1,0 +1,204 @@
+#import "/_tufte_literate.typ": *
+
+#setup(title: [Matrix factorization with Calepin])
+
+= Matrix factorization with Calepin
+
+Matrix factorization represents a rectangular data matrix as the product of
+two thinner matrices. In recommender systems, the rows are users, the columns
+are items, and the observed entries are ratings. A rank #rank-k model writes
+
+#rating-model
+
+where #user-vector is a user vector, #item-vector is an item vector, and
+#global-mean is the global average rating. The dot product is large when the
+user and item point in similar latent directions.#sidenote[The sign and
+rotation of the latent dimensions are not identified. What matters for
+prediction is the dot product, not a unique interpretation of each axis.]
+
+== A small ratings matrix
+
+We will fit a rank-2 model to a tiny ratings matrix. Missing values are written
+as `None`.
+
+```python
+import math
+import random
+
+users = ["Ada", "Ben", "Cy", "Dee", "Eli"]
+items = ["Linear algebra", "Optimization", "Sci-fi", "Cooking"]
+
+ratings = [
+    [5.0, 4.0, None, 1.0],
+    [4.0, None, None, 1.0],
+    [1.0, 1.0, 5.0, 4.0],
+    [None, 1.0, 4.0, 5.0],
+    [5.0, None, 1.0, None],
+]
+
+observed = [
+    (i, j, value)
+    for i, row in enumerate(ratings)
+    for j, value in enumerate(row)
+    if value is not None
+]
+
+def show_matrix(matrix):
+    print("          " + "  ".join(f"{name[:4]:>4}" for name in items))
+    for name, row in zip(users, matrix):
+        cells = ["   ." if value is None else f"{value:4.1f}" for value in row]
+        print(f"{name:>4}      " + "  ".join(cells))
+
+show_matrix(ratings)
+```
+
+The model should use the observed entries to fill in the missing cells. With
+only two latent dimensions, it has to compress the observed pattern rather than
+memorize every rating separately.
+
+== A synthetic rank-2 heatmap
+
+Before fitting the ratings data, it is useful to look at an exactly rank-2
+matrix. The following chunk imports NumPy, generates two skinny factors, and
+plots their product with Matplotlib.
+
+#python-figure(
+  label: "fig-rank-two-heatmap",
+  caption: [Synthetic rank-2 matrix],
+  alt: "Heatmap of a generated rank-2 matrix",
+)[```python
+import numpy as np
+import matplotlib.pyplot as plt
+
+rng = np.random.default_rng(7)
+left = rng.normal(size=(18, 2))
+right = rng.normal(size=(2, 14))
+rank_two = left @ right
+
+plt.figure(figsize=(6, 3.8))
+image = plt.imshow(rank_two, aspect="auto", cmap="viridis")
+plt.title("Synthetic rank-2 matrix")
+plt.xlabel("column")
+plt.ylabel("row")
+plt.colorbar(image, fraction=0.046, pad=0.04, label="value")
+plt.tight_layout()
+```]
+
+In HTML output, this figure is a useful asset-inlining check: a self-contained
+render should embed the generated PNG directly in the page instead of linking
+to a file under `.calepin/`.
+
+== Fitting a rank-2 model
+
+The loss is squared error on observed ratings plus a small penalty that keeps
+the latent vectors from growing too large:
+
+#factorization-loss
+
+Here is a simple stochastic gradient descent fit.
+
+```python
+random.seed(12)
+
+rank = 2
+learning_rate = 0.025
+regularization = 0.02
+epochs = 2400
+
+mu = sum(value for _, _, value in observed) / len(observed)
+user_factors = [
+    [random.uniform(-0.35, 0.35) for _ in range(rank)]
+    for _ in users
+]
+item_factors = [
+    [random.uniform(-0.35, 0.35) for _ in range(rank)]
+    for _ in items
+]
+
+def dot(left, right):
+    return sum(a * b for a, b in zip(left, right))
+
+def predict(i, j):
+    return mu + dot(user_factors[i], item_factors[j])
+
+def rmse():
+    total = 0.0
+    for i, j, value in observed:
+        total += (value - predict(i, j)) ** 2
+    return math.sqrt(total / len(observed))
+
+checkpoints = []
+for epoch in range(epochs + 1):
+    if epoch in (0, 25, 100, 400, 1200, 2400):
+        checkpoints.append((epoch, rmse()))
+    random.shuffle(observed)
+    for i, j, value in observed:
+        error = value - predict(i, j)
+        old_user = user_factors[i][:]
+        old_item = item_factors[j][:]
+        for d in range(rank):
+            user_factors[i][d] += learning_rate * (
+                error * old_item[d] - regularization * old_user[d]
+            )
+            item_factors[j][d] += learning_rate * (
+                error * old_user[d] - regularization * old_item[d]
+            )
+
+for epoch, value in checkpoints:
+    print(f"epoch {epoch:4d}: observed RMSE = {value:.3f}")
+```
+
+#margin-python[
+```python
+def cell(value):
+    return f"[{value}]"
+
+rows = [cell("*Item*"), cell("factor 1"), cell("factor 2")]
+for name, vector in zip(items, item_factors):
+    rows.extend([cell(name), cell(f"{vector[0]:.2f}"), cell(f"{vector[1]:.2f}")])
+
+fragment = (
+    "#figure("
+    "table(columns: 3, inset: 0.28em, "
+    + ", ".join(rows)
+    + "), caption: [Learned item factors])"
+)
+print(fragment)
+```
+]
+
+The margin table is computed from the trained model. The exact coordinate
+system is arbitrary, but nearby items have similar factor vectors.
+
+== Completing the matrix
+
+The fitted model can now predict the missing ratings.
+
+```python
+completed = []
+for i, row in enumerate(ratings):
+    out = []
+    for j, value in enumerate(row):
+        out.append(value if value is not None else predict(i, j))
+    completed.append(out)
+
+show_matrix(completed)
+```
+
+The same fitted object can also list only the originally missing entries.
+
+```python
+for i, row in enumerate(ratings):
+    for j, value in enumerate(row):
+        if value is None:
+            print(f"{users[i]:>3} -> {items[j]:<14} {predict(i, j):.2f}")
+```
+
+== What to check
+
+Matrix factorization is useful because it shares information across rows and
+columns. But this sharing is also a modeling assumption. A practical workflow
+should check prediction error on held-out observed entries, tune the rank
+#rank-k, and inspect whether the completed matrix makes domain sense. Calepin
+is useful here because the prose, the fitted model, and the diagnostics all
+live in the same executable document.

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "bash-kernel" },
     { name = "jupyter-client" },
+    { name = "matplotlib" },
+    { name = "numpy" },
     { name = "plotnine" },
     { name = "zensical" },
 ]
@@ -55,6 +57,8 @@ dependencies = [
 requires-dist = [
     { name = "bash-kernel" },
     { name = "jupyter-client", specifier = ">=8" },
+    { name = "matplotlib", specifier = ">=3.10.9" },
+    { name = "numpy", specifier = ">=2.4.6" },
     { name = "plotnine", specifier = ">=0.15.5" },
     { name = "zensical", specifier = ">=0.0.43" },
 ]


### PR DESCRIPTION
## Summary

This PR adds a built-in `tufte` HTML template and a compact starter workflow for literate Calepin documents. The matrix-factorization example now lives only under `starters/`; it is not part of the docs website source.

### Tufte HTML template

- Adds `--template tufte` as a built-in HTML theme alongside `pico` and `basic`.
- Provides a Palatino-style reading layout with a main text column and right margin gutter.
- Supports `.sidenote`, `.marginnote`, and `.margin-figure` elements, with responsive inline fallback on narrow screens.
- Adds a small sidenote script that converts Typst HTML endnotes into margin sidenotes when native footnotes are used.
- Adds MathML-friendly styling for inline and display math fallback content.

### Starter workflow

- Adds `starters/tufte_starter.typ` as a compact executable starter that demonstrates prose, Typst math, Python chunks, an embedded NumPy/Matplotlib heatmap, sidenotes, and margin figures.
- Moves the Calepin setup, Tufte helpers, MathML fallback helpers, figure defaults, and margin helpers into `starters/_tufte_literate.typ` so the starter source stays focused on the literate-programming content.
- Adds `starters/config.toml` so the starter uses the repo uv environment's Python interpreter.
- Includes `starters/tufte_starter.html` as the rendered starter artifact for quick inspection.

### Docs/dependencies

- Updates CLI/template docs to mention `tufte` as a built-in HTML template.
- Makes `numpy` and `matplotlib` direct docs/starter dependencies; `uv.lock` changes are minimal metadata updates for those direct deps.
- Adjusts one Typst HTML figure test assertion to tolerate Typst 0.14.2's slightly different HTML serialization while preserving the semantic checks.

## Verification

Ran:

```sh
cargo test -q
cargo fmt --check
git diff --check HEAD~1..HEAD
calepin compile starters/tufte_starter.typ --format html --template tufte --config starters/config.toml --quiet
calepin compile starters/tufte_starter.typ /tmp/starter_matrix_factorization.pdf --format pdf --config starters/config.toml --quiet
```

Checked the rendered starter HTML for self-contained image embedding and MathML fallback output:

```text
starters/tufte_starter.html: data_png_count 1, calepin_image_links 0, mathml_count 7
```
