### PR TITLE
Skip the configured website asset-dir during page discovery (fixes #79)

### DIFF
--- a/calepin/src/website/mod.rs
+++ b/calepin/src/website/mod.rs
@@ -333,6 +333,7 @@ fn build_site(args: WebsiteBuildOptions) -> Result<WebsiteBuildResult> {
         config.sidebar.as_ref(),
         config.pages.as_ref(),
         &languages,
+        &asset_dir,
     )?;
     let (menus_plan, mut menu_files) = discover_site_menus(
         &src_dir,
@@ -340,17 +341,19 @@ fn build_site(args: WebsiteBuildOptions) -> Result<WebsiteBuildResult> {
         config.footer.as_ref(),
         config.pages.as_ref(),
         &languages,
+        &asset_dir,
     )?;
     typ_files.append(&mut menu_files);
     let mut included_pages =
-        discover_site_build_pages(&src_dir, config.pages.as_ref(), &languages)?;
+        discover_site_build_pages(&src_dir, config.pages.as_ref(), &languages, &asset_dir)?;
     typ_files.append(&mut included_pages);
     typ_files.extend(implicit_build_pages(&src_dir, &languages));
     typ_files.sort_by_key(|path| rel_posix(&src_dir, path));
     typ_files.dedup();
     let fallback_files = fallback_pages(&src_dir, &languages);
     let page_fingerprints = fingerprint_files(&typ_files)?;
-    let static_files = discover_static_files(&src_dir, config.static_files.as_ref())?;
+    let static_files =
+        discover_static_files(&src_dir, config.static_files.as_ref(), &asset_dir)?;
     let config_dir = config_path.parent().unwrap_or(&src_dir);
     let html_syntax_theme = HtmlSyntaxTheme::from_paths(
         config_dir,

--- a/calepin/src/website/navigation.rs
+++ b/calepin/src/website/navigation.rs
@@ -155,9 +155,10 @@ pub(super) fn discover_site_pages(
     sidebar: Option<&SidebarConfig>,
     pages: Option<&PagesConfig>,
     languages: &Option<Vec<LanguageInfo>>,
+    asset_dir: &Path,
 ) -> Result<(Vec<NavSectionPlan>, Vec<PathBuf>)> {
     let Some(languages) = languages else {
-        return discover_pages(src_dir, sidebar, pages, None);
+        return discover_pages(src_dir, sidebar, pages, None, asset_dir);
     };
     let mut sections = Vec::new();
     let mut files = Vec::new();
@@ -167,6 +168,7 @@ pub(super) fn discover_site_pages(
             sidebar,
             pages,
             Some(language.code.clone()),
+            asset_dir,
         )?;
         language_files.retain(|path| !is_nested_language_page(path, language, languages));
         for section in &mut language_sections {
@@ -188,19 +190,20 @@ pub(super) fn discover_site_menus(
     footer: Option<&FooterConfig>,
     pages: Option<&PagesConfig>,
     languages: &Option<Vec<LanguageInfo>>,
+    asset_dir: &Path,
 ) -> Result<(MenusPlan, Vec<PathBuf>)> {
     let menus = effective_site_menus(menus, footer)?;
     if menus.is_empty() {
         return Ok((MenusPlan::default(), Vec::new()));
     }
     let Some(languages) = languages else {
-        return discover_menus(src_dir, &menus, pages);
+        return discover_menus(src_dir, &menus, pages, asset_dir);
     };
     let mut plan = MenusPlan::default();
     let mut files = Vec::new();
     for language in languages {
         let (mut language_plan, mut language_files) =
-            discover_menus(&language.content_dir, &menus, pages)?;
+            discover_menus(&language.content_dir, &menus, pages, asset_dir)?;
         language_files.retain(|path| !is_nested_language_page(path, language, languages));
         retain_menu_language_items(&mut language_plan, language, languages);
         if !language.is_default {
@@ -268,9 +271,10 @@ pub(super) fn discover_pages(
     sidebar: Option<&SidebarConfig>,
     pages: Option<&PagesConfig>,
     language: Option<String>,
+    asset_dir: &Path,
 ) -> Result<(Vec<NavSectionPlan>, Vec<PathBuf>)> {
     let Some(sidebar) = sidebar else {
-        let mut files = iter_typ_files(src_dir, false, &[PathBuf::from(FALLBACK_PAGE)])?;
+        let mut files = iter_typ_files(src_dir, false, &[PathBuf::from(FALLBACK_PAGE)], asset_dir)?;
         files.retain(|path| !is_page_excluded(src_dir, path, pages));
         let items = files
             .iter()
@@ -296,6 +300,7 @@ pub(super) fn discover_pages(
         src_dir,
         sidebar.show_hidden,
         &[PathBuf::from(FALLBACK_PAGE)],
+        asset_dir,
     )?;
     let all_typ_files = all_typ_files
         .into_iter()
@@ -340,11 +345,12 @@ pub(super) fn discover_menus(
     src_dir: &Path,
     menus: &BTreeMap<String, Vec<MenuItemConfig>>,
     pages: Option<&PagesConfig>,
+    asset_dir: &Path,
 ) -> Result<(MenusPlan, Vec<PathBuf>)> {
     for name in menus.keys() {
         validate_menu_name(name)?;
     }
-    let all_typ_files = iter_typ_files(src_dir, false, &[PathBuf::from(FALLBACK_PAGE)])?;
+    let all_typ_files = iter_typ_files(src_dir, false, &[PathBuf::from(FALLBACK_PAGE)], asset_dir)?;
     let all_typ_files = all_typ_files
         .into_iter()
         .filter(|path| !is_page_excluded(src_dir, path, pages))
@@ -557,13 +563,14 @@ pub(super) fn discover_site_build_pages(
     src_dir: &Path,
     pages: Option<&PagesConfig>,
     languages: &Option<Vec<LanguageInfo>>,
+    asset_dir: &Path,
 ) -> Result<Vec<PathBuf>> {
     let Some(languages) = languages else {
-        return discover_build_pages(src_dir, pages);
+        return discover_build_pages(src_dir, pages, asset_dir);
     };
     let mut files = Vec::new();
     for language in languages {
-        let mut language_files = discover_build_pages(&language.content_dir, pages)?;
+        let mut language_files = discover_build_pages(&language.content_dir, pages, asset_dir)?;
         language_files.retain(|path| !is_nested_language_page(path, language, languages));
         files.append(&mut language_files);
     }
@@ -573,11 +580,12 @@ pub(super) fn discover_site_build_pages(
 pub(super) fn discover_build_pages(
     src_dir: &Path,
     pages: Option<&PagesConfig>,
+    asset_dir: &Path,
 ) -> Result<Vec<PathBuf>> {
     let Some(pages) = pages else {
         return Ok(Vec::new());
     };
-    let all_typ_files = iter_typ_files(src_dir, true, &[PathBuf::from(FALLBACK_PAGE)])?;
+    let all_typ_files = iter_typ_files(src_dir, true, &[PathBuf::from(FALLBACK_PAGE)], asset_dir)?;
     let mut files = BTreeSet::new();
     for pattern in page_patterns(&pages.include) {
         let matches = if has_glob_chars(&pattern) {
@@ -603,13 +611,14 @@ pub(super) fn discover_build_pages(
 pub(super) fn discover_static_files(
     src_dir: &Path,
     static_files: Option<&StaticConfig>,
+    asset_dir: &Path,
 ) -> Result<Vec<PathBuf>> {
     let Some(static_files) = static_files else {
         return Ok(Vec::new());
     };
     let include = static_patterns(&static_files.include, "static.include")?;
     let exclude = static_patterns(&static_files.exclude, "static.exclude")?;
-    let all_files = iter_static_files(src_dir)?;
+    let all_files = iter_static_files(src_dir, asset_dir)?;
     let mut files = BTreeSet::new();
     for pattern in include {
         let matches = if has_glob_chars(&pattern) {
@@ -643,20 +652,25 @@ pub(super) fn discover_static_files(
     Ok(files.into_iter().collect())
 }
 
-fn iter_static_files(src_dir: &Path) -> Result<Vec<PathBuf>> {
+fn iter_static_files(src_dir: &Path, asset_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
-    collect_static_files(src_dir, src_dir, &mut out)?;
+    collect_static_files(src_dir, src_dir, asset_dir, &mut out)?;
     out.sort_by_key(|path| rel_posix(src_dir, path));
     Ok(out)
 }
 
-fn collect_static_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+fn collect_static_files(
+    root: &Path,
+    dir: &Path,
+    asset_dir: &Path,
+    out: &mut Vec<PathBuf>,
+) -> Result<()> {
     collect_files_by(
         root,
         dir,
         out,
-        |rel, _| !path_has_common_skip_dir(rel),
-        |rel, _| !path_has_common_skip_dir(rel),
+        |rel, _| !path_has_common_skip_dir(rel) && !rel.starts_with(asset_dir),
+        |rel, _| !path_has_common_skip_dir(rel) && !rel.starts_with(asset_dir),
     )
 }
 
@@ -1143,10 +1157,11 @@ pub(super) fn iter_typ_files(
     src_dir: &Path,
     include_hidden: bool,
     exclude: &[PathBuf],
+    asset_dir: &Path,
 ) -> Result<Vec<PathBuf>> {
     let exclude = exclude.iter().collect::<BTreeSet<_>>();
     let mut out = Vec::new();
-    collect_typ_files(src_dir, src_dir, include_hidden, &exclude, &mut out)?;
+    collect_typ_files(src_dir, src_dir, include_hidden, &exclude, asset_dir, &mut out)?;
     out.sort_by_key(|path| rel_posix(src_dir, path));
     Ok(out)
 }
@@ -1156,15 +1171,17 @@ fn collect_typ_files(
     dir: &Path,
     include_hidden: bool,
     exclude: &BTreeSet<&PathBuf>,
+    asset_dir: &Path,
     out: &mut Vec<PathBuf>,
 ) -> Result<()> {
     collect_files_by(
         root,
         dir,
         out,
-        |rel, _| include_hidden || !has_hidden_component(rel),
+        |rel, _| (include_hidden || !has_hidden_component(rel)) && !rel.starts_with(asset_dir),
         |rel, path| {
             (include_hidden || !has_hidden_component(rel))
+                && !rel.starts_with(asset_dir)
                 && path.extension().and_then(|ext| ext.to_str()) == Some("typ")
                 && !exclude.contains(&rel.to_path_buf())
         },

--- a/calepin/src/website/tests.rs
+++ b/calepin/src/website/tests.rs
@@ -741,7 +741,8 @@ fn discover_site_pages_does_not_treat_language_dirs_as_default_pages() {
         },
     ]);
 
-    let (_sections, files) = discover_site_pages(src, None, None, &languages).unwrap();
+    let (_sections, files) =
+        discover_site_pages(src, None, None, &languages, Path::new(".calepin")).unwrap();
     let mut rel = files
         .iter()
         .map(|path| rel_posix(src, path))
@@ -752,6 +753,65 @@ fn discover_site_pages_does_not_treat_language_dirs_as_default_pages() {
         rel,
         vec!["about.typ", "fr/about.typ", "fr/index.typ", "index.typ"]
     );
+}
+
+#[test]
+fn discover_site_pages_skips_generated_custom_asset_dir() {
+    // A non-dot `asset-dir` (e.g. the Netlify-recommended `_calepin`) holds
+    // regenerated Typst runtime sources. They must not be rediscovered as
+    // pages: otherwise a second build feeds `_calepin/calepin.typ` back in as
+    // input and the runtime path is doubled (`_calepin/_calepin/...`), see #79.
+    // The default `.calepin` is skipped only because it is hidden, so a custom
+    // visible asset dir needs to be skipped explicitly.
+    let temp = tempfile::tempdir().unwrap();
+    let src = temp.path();
+    fs::write(src.join("index.typ"), "= Home\n").unwrap();
+    fs::create_dir_all(src.join("_calepin").join("index")).unwrap();
+    fs::write(src.join("_calepin").join("calepin.typ"), "// generated\n").unwrap();
+    fs::write(
+        src.join("_calepin").join("index").join("query-source.typ"),
+        "// generated\n",
+    )
+    .unwrap();
+
+    let (sections, files) =
+        discover_site_pages(src, None, None, &None, Path::new("_calepin")).unwrap();
+
+    let rel = files
+        .iter()
+        .map(|path| rel_posix(src, path))
+        .collect::<Vec<_>>();
+    assert_eq!(rel, vec!["index.typ".to_string()]);
+
+    // The nav surface must not reference the generated sources either.
+    let nav_under_asset_dir = sections
+        .iter()
+        .flat_map(|section| section.items.iter())
+        .filter_map(|item| item.path.as_ref())
+        .any(|path| rel_posix(src, path).starts_with("_calepin/"));
+    assert!(!nav_under_asset_dir);
+}
+
+#[test]
+fn discover_static_files_skips_generated_custom_asset_dir() {
+    // A broad `static.include` glob must not sweep the regenerable asset dir
+    // into the output, mirroring the page-discovery guard for #79.
+    let temp = tempfile::tempdir().unwrap();
+    let src = temp.path();
+    fs::write(src.join("logo.svg"), "<svg></svg>").unwrap();
+    fs::create_dir_all(src.join("_calepin")).unwrap();
+    fs::write(src.join("_calepin/calepin.typ"), "// generated\n").unwrap();
+    let config = StaticConfig {
+        include: vec!["logo.svg".to_string(), "_calepin".to_string()],
+        exclude: Vec::new(),
+    };
+
+    let files = discover_static_files(src, Some(&config), Path::new("_calepin")).unwrap();
+    let rels = files
+        .iter()
+        .map(|path| rel_posix(src, path))
+        .collect::<Vec<_>>();
+    assert_eq!(rels, vec!["logo.svg".to_string()]);
 }
 
 #[test]
@@ -772,7 +832,8 @@ fn implicit_build_pages_include_root_home_and_fallback_outside_configured_naviga
         ..SidebarConfig::default()
     };
 
-    let (_sections, files) = discover_site_pages(src, Some(&sidebar), None, &None).unwrap();
+    let (_sections, files) =
+        discover_site_pages(src, Some(&sidebar), None, &None, Path::new(".calepin")).unwrap();
     assert_eq!(
         files
             .iter()
@@ -856,8 +917,10 @@ fn pages_include_adds_build_only_pages() {
     };
 
     let (_sections, nav_files) =
-        discover_site_pages(src, Some(&sidebar), Some(&pages), &None).unwrap();
-    let include_files = discover_site_build_pages(src, Some(&pages), &None).unwrap();
+        discover_site_pages(src, Some(&sidebar), Some(&pages), &None, Path::new(".calepin"))
+            .unwrap();
+    let include_files =
+        discover_site_build_pages(src, Some(&pages), &None, Path::new(".calepin")).unwrap();
 
     assert_eq!(
         nav_files
@@ -888,8 +951,10 @@ fn pages_exclude_removes_pages_from_navigation_and_includes() {
         exclude: vec!["drafts/**".to_string(), "about.typ".to_string()],
     };
 
-    let (_sections, nav_files) = discover_site_pages(src, None, Some(&pages), &None).unwrap();
-    let include_files = discover_site_build_pages(src, Some(&pages), &None).unwrap();
+    let (_sections, nav_files) =
+        discover_site_pages(src, None, Some(&pages), &None, Path::new(".calepin")).unwrap();
+    let include_files =
+        discover_site_build_pages(src, Some(&pages), &None, Path::new(".calepin")).unwrap();
     let required = implicit_build_pages(src, &None);
 
     assert_eq!(
@@ -980,7 +1045,7 @@ fn discover_static_files_includes_files_dirs_and_globs_then_excludes() {
         exclude: vec!["assets/private/**".to_string()],
     };
 
-    let files = discover_static_files(src, Some(&config)).unwrap();
+    let files = discover_static_files(src, Some(&config), Path::new(".calepin")).unwrap();
     let rels = files
         .iter()
         .map(|path| rel_posix(src, path))
@@ -1003,7 +1068,9 @@ fn discover_static_files_rejects_paths_outside_source_directory() {
         exclude: Vec::new(),
     };
 
-    let err = discover_static_files(Path::new("/site/docs"), Some(&config)).unwrap_err();
+    let err =
+        discover_static_files(Path::new("/site/docs"), Some(&config), Path::new(".calepin"))
+            .unwrap_err();
 
     assert!(err.to_string().contains("source directory"));
 }
@@ -2108,7 +2175,15 @@ label = "© 2026 Example"
     );
 
     let (plan, files) =
-        discover_site_menus(src, &config.menus, config.footer.as_ref(), None, &None).unwrap();
+        discover_site_menus(
+            src,
+            &config.menus,
+            config.footer.as_ref(),
+            None,
+            &None,
+            Path::new(".calepin"),
+        )
+        .unwrap();
 
     assert_eq!(
         plan.items["footer"][0].path.as_deref(),
@@ -2138,6 +2213,7 @@ label = "© 2026 Example"
         config.footer.as_ref(),
         None,
         &None,
+        Path::new(".calepin"),
     )
     .unwrap_err();
 
@@ -2180,7 +2256,7 @@ fn discover_menus_resolves_named_menus_and_orders_by_weight() {
         ),
     ]);
 
-    let (plan, files) = discover_menus(src, &menus, None).unwrap();
+    let (plan, files) = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap();
 
     assert_eq!(
         plan.items["main"][0].path.as_deref(),
@@ -2223,7 +2299,7 @@ fn discover_menus_allows_footer_items_without_targets() {
         ],
     )]);
 
-    let (plan, files) = discover_menus(src, &menus, None).unwrap();
+    let (plan, files) = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap();
 
     assert_eq!(
         plan.items["footer"][0].path.as_deref(),
@@ -2250,7 +2326,7 @@ fn discover_menus_rejects_linkless_items_for_non_footer_menus() {
         }],
     )]);
 
-    let err = discover_menus(src, &menus, None).unwrap_err();
+    let err = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err.to_string().contains("item must set path, glob, or url"));
 }
@@ -2261,7 +2337,7 @@ fn discover_menus_rejects_invalid_menu_names() {
     let src = temp.path();
     let menus = BTreeMap::from([("Main Nav".to_string(), Vec::new())]);
 
-    let err = discover_menus(src, &menus, None).unwrap_err();
+    let err = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err.to_string().contains("invalid menu name `Main Nav`"));
 }
@@ -2365,7 +2441,8 @@ fn discover_pages_resolves_sidebar_page_targets() {
         ..SidebarConfig::default()
     };
 
-    let (sections, files) = discover_pages(src, Some(&sidebar), None, None).unwrap();
+    let (sections, files) =
+        discover_pages(src, Some(&sidebar), None, None, Path::new(".calepin")).unwrap();
 
     assert_eq!(
         files
@@ -2397,7 +2474,7 @@ fn discover_pages_rejects_sidebar_targets_outside_source_directory() {
         ..SidebarConfig::default()
     };
 
-    let err = discover_pages(&src, Some(&sidebar), None, None).unwrap_err();
+    let err = discover_pages(&src, Some(&sidebar), None, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err.to_string().contains("source directory"));
 }
@@ -2422,7 +2499,8 @@ fn discover_pages_applies_pages_exclude_to_explicit_sidebar_targets() {
         ..SidebarConfig::default()
     };
 
-    let (sections, files) = discover_pages(&src, Some(&sidebar), Some(&pages), None).unwrap();
+    let (sections, files) =
+        discover_pages(&src, Some(&sidebar), Some(&pages), None, Path::new(".calepin")).unwrap();
 
     assert!(files.is_empty());
     assert!(sections[0].items.is_empty());
@@ -2443,7 +2521,7 @@ fn discover_pages_rejects_sidebar_external_targets() {
         ..SidebarConfig::default()
     };
 
-    let err = discover_pages(src, Some(&sidebar), None, None).unwrap_err();
+    let err = discover_pages(src, Some(&sidebar), None, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err
         .to_string()
@@ -2466,7 +2544,7 @@ fn discover_pages_rejects_target_combined_with_glob() {
         ..SidebarConfig::default()
     };
 
-    let err = discover_pages(src, Some(&sidebar), None, None).unwrap_err();
+    let err = discover_pages(src, Some(&sidebar), None, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err
         .to_string()
@@ -2499,7 +2577,7 @@ fn discover_menus_rejects_target_combined_with_glob() {
         }],
     )]);
 
-    let err = discover_menus(src, &menus, None).unwrap_err();
+    let err = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err
         .to_string()
@@ -2520,7 +2598,7 @@ fn discover_menus_rejects_targets_outside_source_directory() {
         }],
     )]);
 
-    let err = discover_menus(&src, &menus, None).unwrap_err();
+    let err = discover_menus(&src, &menus, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err.to_string().contains("source directory"));
 }
@@ -2536,7 +2614,8 @@ fn discover_site_build_pages_rejects_include_paths_outside_source_directory() {
         ..PagesConfig::default()
     };
 
-    let err = discover_site_build_pages(&src, Some(&pages), &None).unwrap_err();
+    let err =
+        discover_site_build_pages(&src, Some(&pages), &None, Path::new(".calepin")).unwrap_err();
 
     assert!(err.to_string().contains("source directory"));
 }
@@ -2554,7 +2633,7 @@ fn discover_menus_rejects_unsafe_literal_url_targets() {
         }],
     )]);
 
-    let err = discover_menus(src, &menus, None).unwrap_err();
+    let err = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap_err();
 
     assert!(err.to_string().contains("unsafe URL"));
 }
@@ -2572,7 +2651,7 @@ fn discover_menus_keeps_absolute_url_targets_ending_in_typ_as_urls() {
         }],
     )]);
 
-    let (plan, files) = discover_menus(src, &menus, None).unwrap();
+    let (plan, files) = discover_menus(src, &menus, None, Path::new(".calepin")).unwrap();
 
     assert!(files.is_empty());
     assert_eq!(


### PR DESCRIPTION
Fixes #79.

## Problem

Setting a relative non-dot `asset-dir` (e.g. the Netlify-recommended `_calepin`) makes the **second** `calepin compile` fail with a doubled runtime path:

```
Error: failed to scan .../_calepin/calepin.typ
  error: file not found (searched at .../_calepin/_calepin/calepin/runtime/core/state.typ)
    while including `/_calepin/_calepin/calepin/query-source.typ`
```

The issue framed this as `asset_dir` being "joined twice," but that's a downstream symptom. The real cause: website page/static discovery only skips **hidden** directories. The default `.calepin` is excluded because it starts with a dot — a custom visible asset dir like `_calepin` is not.

The first build succeeds (the dir doesn't exist yet when discovery runs), but the **second** build rediscovers the generated Typst runtime sources under `_calepin/` as source pages. Scanning `_calepin/calepin.typ` then derives its artifact path as `_calepin/_calepin/calepin/…`, the runtime imports can't be resolved, and the compile fails.

## Fix

Thread the resolved `asset_dir` into the discovery walkers (`iter_typ_files`/`collect_typ_files`, `iter_static_files`/`collect_static_files`) and the `discover_*` chain in `website/navigation.rs`, skipping any path under it (`!rel.starts_with(asset_dir)`). This mirrors how the filesystem watcher already excludes the asset dir via `path_has_skip_dir`. The default `.calepin` behavior is unchanged.

## Tests

Two regression tests in `website/tests.rs`:
- `discover_site_pages_skips_generated_custom_asset_dir`
- `discover_static_files_skips_generated_custom_asset_dir`

Also verified by hand: reproduced the second-build failure with `asset-dir = "_calepin"`, then confirmed repeated builds succeed after the fix.

## Notes / out of scope

- The issue's secondary suggestion — themes that inline their assets not emitting a stray `.calepin/website-manifest.json` — is not addressed here.
- Separately, when the output dir lives **under** the source dir (e.g. `calepin compile . public`), discovery also walks the output dir on rebuilds (`public/public/…`). That's an independent, pre-existing issue unrelated to `asset-dir` and is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)