### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Cargo.lock
 pagefind/
 .DS_Store
 fingerprint.xxh3
+/result
 
 __pycache__
 .claude

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,12 @@ bump: ## Bump package version (usage: make bump VERSION=x.y.z)
 	    exit 1; \
 	fi
 	@sed -i.bak -E 's/^version = "[^"]*"/version = "$(VERSION)"/' calepin/Cargo.toml && rm calepin/Cargo.toml.bak
+	@sed -i.bak -E 's/^([[:space:]]+version = )"[0-9]+\.[0-9]+\.[0-9]+"/\1"$(VERSION)"/' flake.nix && rm flake.nix.bak
 	@cargo update -w >/dev/null
 	@echo "Bumped calepin to $(VERSION)."
-	@git diff --stat calepin/Cargo.toml Cargo.lock
+	@git diff --stat calepin/Cargo.toml Cargo.lock flake.nix
 	@echo ""
-	@echo "Next: update docs if needed, commit calepin/Cargo.toml + Cargo.lock, then 'make release'."
+	@echo "Next: update docs if needed, commit calepin/Cargo.toml + Cargo.lock + flake.nix, then 'make release'."
 
 # Tag the current commit and push the tag. This triggers:
 #   - .github/workflows/release.yml        cargo-dist binaries and installers

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Calepin - Computational Notebooks and Static Websites in typst.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "calepin";
+          version = "0.0.30";
+
+          src = ./.;
+
+          cargoLock.lockFile = ./Cargo.lock;
+          buildAndTestSubdir = "calepin";
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          postFixup = ''
+            wrapProgram $out/bin/calepin \
+              --suffix PATH : ${pkgs.lib.makeBinPath [ pkgs.typst ]}
+          '';
+
+          meta = with pkgs.lib; {
+            description = "A Rust CLI for preprocessing Typst documents with executable code chunks";
+            homepage = "https://vincentarelbundock.github.io/calepin";
+            license = licenses.mit;
+            mainProgram = "calepin";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          shellHook = ''
+            export PATH="$PWD/target/debug:$PATH"
+            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
+          '';
+          packages = with pkgs; [
+            # Rust
+            cargo
+            rustc
+            clippy
+            rust-analyzer
+            rustfmt
+            # Node
+            nodejs
+            # Python
+            uv
+            # R for docs
+            (rWrapper.override {
+              packages = with rPackages; [ ggplot2 tinytable ];
+            })
+            # Other
+            typst
+          ];
+        };
+      });
+}


### PR DESCRIPTION
Hello,

This PR adds a nix flake.

It exposes `calepin` as an output (wrapped with `typst` in `PATH`, I believe this is the bare minimum to use `calepin`).

Furthermore, it creates the minimum dev env that at least allows to build the website.

Thanks in advance!